### PR TITLE
fix: resolve YAML syntax error in F5 XC API contract

### DIFF
--- a/specs/001-ce-cicd-automation/contracts/f5-xc-api.yaml
+++ b/specs/001-ce-cicd-automation/contracts/f5-xc-api.yaml
@@ -27,9 +27,7 @@ paths:
       summary: Create Azure VNET Site
       description: |
         Creates a new Azure VNET site in F5 XC Console and generates registration token.
-        This is called by Terraform volt
-
-erra provider to initialize CE site.
+        This is called by Terraform volterra provider to initialize CE site.
       operationId: createAzureVnetSite
       tags:
         - Site Management


### PR DESCRIPTION
## Summary
Fixes #40 - YAML syntax error in F5 XC API contract specification

## Changes
- Fixed split line between "volt" and "erra" in description field
- Joined lines 30-32 to properly form "Terraform volterra provider to initialize CE site"

## Root Cause
YAML description field had an unintended line break that split the word "volterra":
```yaml
volt

erra provider
```

## Testing
- ✅ Pre-commit `check-yaml` hook now passes
- ✅ YAML validation successful
- ✅ All pre-commit checks pass for this change

## Files Changed
- `specs/001-ce-cicd-automation/contracts/f5-xc-api.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)