### PR TITLE
fix: resolve yamllint line-length violations in terraform-destroy workflow

### DIFF
--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -139,7 +139,8 @@ jobs:
         run: |
           echo "## 🧹 Cleanup Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Run \`scripts/cleanup-orphaned-resources.sh\` if needed to clean up any orphaned resources." >> $GITHUB_STEP_SUMMARY
+          echo "Run \`scripts/cleanup-orphaned-resources.sh\` if needed to " >> $GITHUB_STEP_SUMMARY
+          echo "clean up any orphaned resources." >> $GITHUB_STEP_SUMMARY
 
       - name: Destruction Summary
         run: |
@@ -151,4 +152,5 @@ jobs:
           echo "**Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "**Confirmation**: ${{ github.event.inputs.confirmation }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "⚠️ **Note**: This action is irreversible. State file has been updated to reflect destruction." >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ **Note**: This action is irreversible. State file has been" >> $GITHUB_STEP_SUMMARY
+          echo "updated to reflect destruction." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Fixes #41 - Yamllint line-length violations in GitHub Actions workflow

## Changes
- Split long lines in `.github/workflows/terraform-destroy.yml`
- Line 142: Split cleanup message across two lines
- Line 154: Split warning message across two lines  
- Complies with yamllint 120 character line-length rule

## Root Cause
Two echo statements exceeded the 120 character limit configured in yamllint:
```yaml
# Line 142 was 135 characters
# Line 154 was 127 characters
```

## Testing
- ✅ Pre-commit `yamllint` hook now passes
- ✅ YAML remains valid after line splits
- ✅ All pre-commit checks pass for this change

## Files Changed
- `.github/workflows/terraform-destroy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)