### PR TITLE
fix: replace invalid peering_state attribute with id in spoke VNet outputs

### DIFF
--- a/terraform/modules/azure-spoke-vnet/outputs.tf
+++ b/terraform/modules/azure-spoke-vnet/outputs.tf
@@ -21,8 +21,8 @@ output "peering_id" {
 }
 
 output "peering_status" {
-  description = "Status of the VNET peering"
-  value       = azurerm_virtual_network_peering.spoke_to_hub.peering_state
+  description = "Status of the VNET peering (ID indicates peering exists)"
+  value       = azurerm_virtual_network_peering.spoke_to_hub.id
 }
 
 output "route_table_id" {


### PR DESCRIPTION
## Summary
Fixes #44 - Invalid `peering_state` attribute in terraform outputs

## Changes
- Replaced `azurerm_virtual_network_peering.spoke_to_hub.peering_state` with `.id`
- Updated description: "Status of the VNET peering (ID indicates peering exists)"

## Root Cause
The `peering_state` attribute does not exist in the azurerm_virtual_network_peering resource schema.

## Testing
- ✅ Terraform validate passes
- ✅ Output provides valid peering information

## Files Changed
- `terraform/modules/azure-spoke-vnet/outputs.tf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)