### PR TITLE
fix: apply shfmt formatting to all bash scripts

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -3,82 +3,82 @@
 
 # Get repository root, with fallback for non-git repositories
 get_repo_root() {
-    if git rev-parse --show-toplevel >/dev/null 2>&1; then
-        git rev-parse --show-toplevel
-    else
-        # Fall back to script location for non-git repos
-        local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        (cd "$script_dir/../../.." && pwd)
-    fi
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    git rev-parse --show-toplevel
+  else
+    # Fall back to script location for non-git repos
+    local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    (cd "$script_dir/../../.." && pwd)
+  fi
 }
 
 # Get current branch, with fallback for non-git repositories
 get_current_branch() {
-    # First check if SPECIFY_FEATURE environment variable is set
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
+  # First check if SPECIFY_FEATURE environment variable is set
+  if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+    echo "$SPECIFY_FEATURE"
+    return
+  fi
 
-    # Then check git if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
+  # Then check git if available
+  if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
+    git rev-parse --abbrev-ref HEAD
+    return
+  fi
 
-    # For non-git repos, try to find the latest feature directory
-    local repo_root=$(get_repo_root)
-    local specs_dir="$repo_root/specs"
+  # For non-git repos, try to find the latest feature directory
+  local repo_root=$(get_repo_root)
+  local specs_dir="$repo_root/specs"
 
-    if [[ -d "$specs_dir" ]]; then
-        local latest_feature=""
-        local highest=0
+  if [[ -d "$specs_dir" ]]; then
+    local latest_feature=""
+    local highest=0
 
-        for dir in "$specs_dir"/*; do
-            if [[ -d "$dir" ]]; then
-                local dirname=$(basename "$dir")
-                if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
-                    local number=${BASH_REMATCH[1]}
-                    number=$((10#$number))
-                    if [[ "$number" -gt "$highest" ]]; then
-                        highest=$number
-                        latest_feature=$dirname
-                    fi
-                fi
-            fi
-        done
-
-        if [[ -n "$latest_feature" ]]; then
-            echo "$latest_feature"
-            return
+    for dir in "$specs_dir"/*; do
+      if [[ -d "$dir" ]]; then
+        local dirname=$(basename "$dir")
+        if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+          local number=${BASH_REMATCH[1]}
+          number=$((10#$number))
+          if [[ "$number" -gt "$highest" ]]; then
+            highest=$number
+            latest_feature=$dirname
+          fi
         fi
-    fi
+      fi
+    done
 
-    echo "main"  # Final fallback
+    if [[ -n "$latest_feature" ]]; then
+      echo "$latest_feature"
+      return
+    fi
+  fi
+
+  echo "main" # Final fallback
 }
 
 # Check if we have git available
 has_git() {
-    git rev-parse --show-toplevel >/dev/null 2>&1
+  git rev-parse --show-toplevel >/dev/null 2>&1
 }
 
 check_feature_branch() {
-    local branch="$1"
-    local has_git_repo="$2"
+  local branch="$1"
+  local has_git_repo="$2"
 
-    # For non-git repos, we can't enforce branch naming but still provide output
-    if [[ "$has_git_repo" != "true" ]]; then
-        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
-        return 0
-    fi
-
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
-        echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
-        return 1
-    fi
-
+  # For non-git repos, we can't enforce branch naming but still provide output
+  if [[ "$has_git_repo" != "true" ]]; then
+    echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
     return 0
+  fi
+
+  if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
+    echo "Feature branches should be named like: 001-feature-name" >&2
+    return 1
+  fi
+
+  return 0
 }
 
 get_feature_dir() { echo "$1/specs/$2"; }
@@ -86,57 +86,57 @@ get_feature_dir() { echo "$1/specs/$2"; }
 # Find feature directory by numeric prefix instead of exact branch match
 # This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
 find_feature_dir_by_prefix() {
-    local repo_root="$1"
-    local branch_name="$2"
-    local specs_dir="$repo_root/specs"
+  local repo_root="$1"
+  local branch_name="$2"
+  local specs_dir="$repo_root/specs"
 
-    # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
-    if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
-        # If branch doesn't have numeric prefix, fall back to exact match
-        echo "$specs_dir/$branch_name"
-        return
-    fi
+  # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
+  if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
+    # If branch doesn't have numeric prefix, fall back to exact match
+    echo "$specs_dir/$branch_name"
+    return
+  fi
 
-    local prefix="${BASH_REMATCH[1]}"
+  local prefix="${BASH_REMATCH[1]}"
 
-    # Search for directories in specs/ that start with this prefix
-    local matches=()
-    if [[ -d "$specs_dir" ]]; then
-        for dir in "$specs_dir"/"$prefix"-*; do
-            if [[ -d "$dir" ]]; then
-                matches+=("$(basename "$dir")")
-            fi
-        done
-    fi
+  # Search for directories in specs/ that start with this prefix
+  local matches=()
+  if [[ -d "$specs_dir" ]]; then
+    for dir in "$specs_dir"/"$prefix"-*; do
+      if [[ -d "$dir" ]]; then
+        matches+=("$(basename "$dir")")
+      fi
+    done
+  fi
 
-    # Handle results
-    if [[ ${#matches[@]} -eq 0 ]]; then
-        # No match found - return the branch name path (will fail later with clear error)
-        echo "$specs_dir/$branch_name"
-    elif [[ ${#matches[@]} -eq 1 ]]; then
-        # Exactly one match - perfect!
-        echo "$specs_dir/${matches[0]}"
-    else
-        # Multiple matches - this shouldn't happen with proper naming convention
-        echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
-        echo "Please ensure only one spec directory exists per numeric prefix." >&2
-        echo "$specs_dir/$branch_name"  # Return something to avoid breaking the script
-    fi
+  # Handle results
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    # No match found - return the branch name path (will fail later with clear error)
+    echo "$specs_dir/$branch_name"
+  elif [[ ${#matches[@]} -eq 1 ]]; then
+    # Exactly one match - perfect!
+    echo "$specs_dir/${matches[0]}"
+  else
+    # Multiple matches - this shouldn't happen with proper naming convention
+    echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
+    echo "Please ensure only one spec directory exists per numeric prefix." >&2
+    echo "$specs_dir/$branch_name" # Return something to avoid breaking the script
+  fi
 }
 
 get_feature_paths() {
-    local repo_root=$(get_repo_root)
-    local current_branch=$(get_current_branch)
-    local has_git_repo="false"
+  local repo_root=$(get_repo_root)
+  local current_branch=$(get_current_branch)
+  local has_git_repo="false"
 
-    if has_git; then
-        has_git_repo="true"
-    fi
+  if has_git; then
+    has_git_repo="true"
+  fi
 
-    # Use prefix-based lookup to support multiple branches per spec
-    local feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
+  # Use prefix-based lookup to support multiple branches per spec
+  local feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
 
-    cat <<EOF
+  cat <<EOF
 REPO_ROOT='$repo_root'
 CURRENT_BRANCH='$current_branch'
 HAS_GIT='$has_git_repo'
@@ -153,4 +153,3 @@ EOF
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
-

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -7,62 +7,62 @@ SHORT_NAME=""
 ARGS=()
 i=1
 while [ $i -le $# ]; do
-    arg="${!i}"
-    case "$arg" in
-        --json) 
-            JSON_MODE=true 
-            ;;
-        --short-name)
-            if [ $((i + 1)) -gt $# ]; then
-                echo 'Error: --short-name requires a value' >&2
-                exit 1
-            fi
-            i=$((i + 1))
-            next_arg="${!i}"
-            # Check if the next argument is another option (starts with --)
-            if [[ "$next_arg" == --* ]]; then
-                echo 'Error: --short-name requires a value' >&2
-                exit 1
-            fi
-            SHORT_NAME="$next_arg"
-            ;;
-        --help|-h) 
-            echo "Usage: $0 [--json] [--short-name <name>] <feature_description>"
-            echo ""
-            echo "Options:"
-            echo "  --json              Output in JSON format"
-            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
-            echo "  --help, -h          Show this help message"
-            echo ""
-            echo "Examples:"
-            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
-            echo "  $0 'Implement OAuth2 integration for API'"
-            exit 0
-            ;;
-        *) 
-            ARGS+=("$arg") 
-            ;;
-    esac
-    i=$((i + 1))
+  arg="${!i}"
+  case "$arg" in
+    --json)
+      JSON_MODE=true
+      ;;
+    --short-name)
+      if [ $((i + 1)) -gt $# ]; then
+        echo 'Error: --short-name requires a value' >&2
+        exit 1
+      fi
+      i=$((i + 1))
+      next_arg="${!i}"
+      # Check if the next argument is another option (starts with --)
+      if [[ "$next_arg" == --* ]]; then
+        echo 'Error: --short-name requires a value' >&2
+        exit 1
+      fi
+      SHORT_NAME="$next_arg"
+      ;;
+    --help | -h)
+      echo "Usage: $0 [--json] [--short-name <name>] <feature_description>"
+      echo ""
+      echo "Options:"
+      echo "  --json              Output in JSON format"
+      echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+      echo "  --help, -h          Show this help message"
+      echo ""
+      echo "Examples:"
+      echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+      echo "  $0 'Implement OAuth2 integration for API'"
+      exit 0
+      ;;
+    *)
+      ARGS+=("$arg")
+      ;;
+  esac
+  i=$((i + 1))
 done
 
 FEATURE_DESCRIPTION="${ARGS[*]}"
 if [ -z "$FEATURE_DESCRIPTION" ]; then
-    echo "Usage: $0 [--json] [--short-name <name>] <feature_description>" >&2
-    exit 1
+  echo "Usage: $0 [--json] [--short-name <name>] <feature_description>" >&2
+  exit 1
 fi
 
 # Function to find the repository root by searching for existing project markers
 find_repo_root() {
-    local dir="$1"
-    while [ "$dir" != "/" ]; do
-        if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
 }
 
 # Resolve repository root. Prefer git information when available, but fall back
@@ -71,15 +71,15 @@ find_repo_root() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
-    REPO_ROOT=$(git rev-parse --show-toplevel)
-    HAS_GIT=true
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  HAS_GIT=true
 else
-    REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
-    if [ -z "$REPO_ROOT" ]; then
-        echo "Error: Could not determine repository root. Please run this script from within the repository." >&2
-        exit 1
-    fi
-    HAS_GIT=false
+  REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
+  if [ -z "$REPO_ROOT" ]; then
+    echo "Error: Could not determine repository root. Please run this script from within the repository." >&2
+    exit 1
+  fi
+  HAS_GIT=false
 fi
 
 cd "$REPO_ROOT"
@@ -89,13 +89,13 @@ mkdir -p "$SPECS_DIR"
 
 HIGHEST=0
 if [ -d "$SPECS_DIR" ]; then
-    for dir in "$SPECS_DIR"/*; do
-        [ -d "$dir" ] || continue
-        dirname=$(basename "$dir")
-        number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
-        number=$((10#$number))
-        if [ "$number" -gt "$HIGHEST" ]; then HIGHEST=$number; fi
-    done
+  for dir in "$SPECS_DIR"/*; do
+    [ -d "$dir" ] || continue
+    dirname=$(basename "$dir")
+    number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
+    number=$((10#$number))
+    if [ "$number" -gt "$HIGHEST" ]; then HIGHEST=$number; fi
+  done
 fi
 
 NEXT=$((HIGHEST + 1))
@@ -103,58 +103,58 @@ FEATURE_NUM=$(printf "%03d" "$NEXT")
 
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
-    local description="$1"
-    
-    # Common stop words to filter out
-    local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
-    
-    # Convert to lowercase and split into words
-    local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
-    
-    # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
-    local meaningful_words=()
-    for word in $clean_name; do
-        # Skip empty words
-        [ -z "$word" ] && continue
-        
-        # Keep words that are NOT stop words AND (length >= 3 OR are potential acronyms)
-        if ! echo "$word" | grep -qiE "$stop_words"; then
-            if [ ${#word} -ge 3 ]; then
-                meaningful_words+=("$word")
-            elif echo "$description" | grep -q "\b${word^^}\b"; then
-                # Keep short words if they appear as uppercase in original (likely acronyms)
-                meaningful_words+=("$word")
-            fi
-        fi
-    done
-    
-    # If we have meaningful words, use first 3-4 of them
-    if [ ${#meaningful_words[@]} -gt 0 ]; then
-        local max_words=3
-        if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
-        
-        local result=""
-        local count=0
-        for word in "${meaningful_words[@]}"; do
-            if [ $count -ge $max_words ]; then break; fi
-            if [ -n "$result" ]; then result="$result-"; fi
-            result="$result$word"
-            count=$((count + 1))
-        done
-        echo "$result"
-    else
-        # Fallback to original logic if no meaningful words found
-        echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//' | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+  local description="$1"
+
+  # Common stop words to filter out
+  local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
+
+  # Convert to lowercase and split into words
+  local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
+
+  # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
+  local meaningful_words=()
+  for word in $clean_name; do
+    # Skip empty words
+    [ -z "$word" ] && continue
+
+    # Keep words that are NOT stop words AND (length >= 3 OR are potential acronyms)
+    if ! echo "$word" | grep -qiE "$stop_words"; then
+      if [ ${#word} -ge 3 ]; then
+        meaningful_words+=("$word")
+      elif echo "$description" | grep -q "\b${word^^}\b"; then
+        # Keep short words if they appear as uppercase in original (likely acronyms)
+        meaningful_words+=("$word")
+      fi
     fi
+  done
+
+  # If we have meaningful words, use first 3-4 of them
+  if [ ${#meaningful_words[@]} -gt 0 ]; then
+    local max_words=3
+    if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
+
+    local result=""
+    local count=0
+    for word in "${meaningful_words[@]}"; do
+      if [ $count -ge $max_words ]; then break; fi
+      if [ -n "$result" ]; then result="$result-"; fi
+      result="$result$word"
+      count=$((count + 1))
+    done
+    echo "$result"
+  else
+    # Fallback to original logic if no meaningful words found
+    echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//' | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+  fi
 }
 
 # Generate branch name
 if [ -n "$SHORT_NAME" ]; then
-    # Use provided short name, just clean it up
-    BRANCH_SUFFIX=$(echo "$SHORT_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//')
+  # Use provided short name, just clean it up
+  BRANCH_SUFFIX=$(echo "$SHORT_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//')
 else
-    # Generate from description with smart filtering
-    BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
+  # Generate from description with smart filtering
+  BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
 fi
 
 BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
@@ -163,27 +163,27 @@ BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 # Validate and truncate if necessary
 MAX_BRANCH_LENGTH=244
 if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
-    # Calculate how much we need to trim from suffix
-    # Account for: feature number (3) + hyphen (1) = 4 chars
-    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
-    
-    # Truncate suffix at word boundary if possible
-    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
-    # Remove trailing hyphen if truncation created one
-    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
-    
-    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
-    
-    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
-    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
-    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+  # Calculate how much we need to trim from suffix
+  # Account for: feature number (3) + hyphen (1) = 4 chars
+  MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+
+  # Truncate suffix at word boundary if possible
+  TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+  # Remove trailing hyphen if truncation created one
+  TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+  ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+  BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+  echo >&2 "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+  echo >&2 "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+  echo >&2 "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
 if [ "$HAS_GIT" = true ]; then
-    git checkout -b "$BRANCH_NAME"
+  git checkout -b "$BRANCH_NAME"
 else
-    >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+  echo >&2 "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
@@ -197,10 +197,10 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+  printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
 else
-    echo "BRANCH_NAME: $BRANCH_NAME"
-    echo "SPEC_FILE: $SPEC_FILE"
-    echo "FEATURE_NUM: $FEATURE_NUM"
-    echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
+  echo "BRANCH_NAME: $BRANCH_NAME"
+  echo "SPEC_FILE: $SPEC_FILE"
+  echo "FEATURE_NUM: $FEATURE_NUM"
+  echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
 fi

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -2,7 +2,7 @@
 
 # Update agent context files with information from plan.md
 #
-# This script maintains AI agent context files by parsing feature specifications 
+# This script maintains AI agent context files by parsing feature specifications
 # and updating agent-specific configuration files with project information.
 #
 # MAIN FUNCTIONS:
@@ -53,12 +53,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+eval "$(get_feature_paths)"
 
-NEW_PLAN="$IMPL_PLAN"  # Alias for compatibility with existing code
+NEW_PLAN="$IMPL_PLAN" # Alias for compatibility with existing code
 AGENT_TYPE="${1:-}"
 
-# Agent-specific file paths  
+# Agent-specific file paths
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
 COPILOT_FILE="$REPO_ROOT/.github/copilot-instructions.md"
@@ -86,27 +86,27 @@ NEW_PROJECT_TYPE=""
 #==============================================================================
 
 log_info() {
-    echo "INFO: $1"
+  echo "INFO: $1"
 }
 
 log_success() {
-    echo "✓ $1"
+  echo "✓ $1"
 }
 
 log_error() {
-    echo "ERROR: $1" >&2
+  echo "ERROR: $1" >&2
 }
 
 log_warning() {
-    echo "WARNING: $1" >&2
+  echo "WARNING: $1" >&2
 }
 
 # Cleanup function for temporary files
 cleanup() {
-    local exit_code=$?
-    rm -f /tmp/agent_update_*_$$
-    rm -f /tmp/manual_additions_$$
-    exit $exit_code
+  local exit_code=$?
+  rm -f /tmp/agent_update_*_$$
+  rm -f /tmp/manual_additions_$$
+  exit $exit_code
 }
 
 # Set up cleanup trap
@@ -117,32 +117,32 @@ trap cleanup EXIT INT TERM
 #==============================================================================
 
 validate_environment() {
-    # Check if we have a current branch/feature (git or non-git)
-    if [[ -z "$CURRENT_BRANCH" ]]; then
-        log_error "Unable to determine current feature"
-        if [[ "$HAS_GIT" == "true" ]]; then
-            log_info "Make sure you're on a feature branch"
-        else
-            log_info "Set SPECIFY_FEATURE environment variable or create a feature first"
-        fi
-        exit 1
+  # Check if we have a current branch/feature (git or non-git)
+  if [[ -z "$CURRENT_BRANCH" ]]; then
+    log_error "Unable to determine current feature"
+    if [[ "$HAS_GIT" == "true" ]]; then
+      log_info "Make sure you're on a feature branch"
+    else
+      log_info "Set SPECIFY_FEATURE environment variable or create a feature first"
     fi
-    
-    # Check if plan.md exists
-    if [[ ! -f "$NEW_PLAN" ]]; then
-        log_error "No plan.md found at $NEW_PLAN"
-        log_info "Make sure you're working on a feature with a corresponding spec directory"
-        if [[ "$HAS_GIT" != "true" ]]; then
-            log_info "Use: export SPECIFY_FEATURE=your-feature-name or create a new feature first"
-        fi
-        exit 1
+    exit 1
+  fi
+
+  # Check if plan.md exists
+  if [[ ! -f "$NEW_PLAN" ]]; then
+    log_error "No plan.md found at $NEW_PLAN"
+    log_info "Make sure you're working on a feature with a corresponding spec directory"
+    if [[ "$HAS_GIT" != "true" ]]; then
+      log_info "Use: export SPECIFY_FEATURE=your-feature-name or create a new feature first"
     fi
-    
-    # Check if template exists (needed for new files)
-    if [[ ! -f "$TEMPLATE_FILE" ]]; then
-        log_warning "Template file not found at $TEMPLATE_FILE"
-        log_warning "Creating new agent files will fail"
-    fi
+    exit 1
+  fi
+
+  # Check if template exists (needed for new files)
+  if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    log_warning "Template file not found at $TEMPLATE_FILE"
+    log_warning "Creating new agent files will fail"
+  fi
 }
 
 #==============================================================================
@@ -150,79 +150,79 @@ validate_environment() {
 #==============================================================================
 
 extract_plan_field() {
-    local field_pattern="$1"
-    local plan_file="$2"
-    
-    grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null | \
-        head -1 | \
-        sed "s|^\*\*${field_pattern}\*\*: ||" | \
-        sed 's/^[ \t]*//;s/[ \t]*$//' | \
-        grep -v "NEEDS CLARIFICATION" | \
-        grep -v "^N/A$" || echo ""
+  local field_pattern="$1"
+  local plan_file="$2"
+
+  grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null |
+    head -1 |
+    sed "s|^\*\*${field_pattern}\*\*: ||" |
+    sed 's/^[ \t]*//;s/[ \t]*$//' |
+    grep -v "NEEDS CLARIFICATION" |
+    grep -v "^N/A$" || echo ""
 }
 
 parse_plan_data() {
-    local plan_file="$1"
-    
-    if [[ ! -f "$plan_file" ]]; then
-        log_error "Plan file not found: $plan_file"
-        return 1
-    fi
-    
-    if [[ ! -r "$plan_file" ]]; then
-        log_error "Plan file is not readable: $plan_file"
-        return 1
-    fi
-    
-    log_info "Parsing plan data from $plan_file"
-    
-    NEW_LANG=$(extract_plan_field "Language/Version" "$plan_file")
-    NEW_FRAMEWORK=$(extract_plan_field "Primary Dependencies" "$plan_file")
-    NEW_DB=$(extract_plan_field "Storage" "$plan_file")
-    NEW_PROJECT_TYPE=$(extract_plan_field "Project Type" "$plan_file")
-    
-    # Log what we found
-    if [[ -n "$NEW_LANG" ]]; then
-        log_info "Found language: $NEW_LANG"
-    else
-        log_warning "No language information found in plan"
-    fi
-    
-    if [[ -n "$NEW_FRAMEWORK" ]]; then
-        log_info "Found framework: $NEW_FRAMEWORK"
-    fi
-    
-    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
-        log_info "Found database: $NEW_DB"
-    fi
-    
-    if [[ -n "$NEW_PROJECT_TYPE" ]]; then
-        log_info "Found project type: $NEW_PROJECT_TYPE"
-    fi
+  local plan_file="$1"
+
+  if [[ ! -f "$plan_file" ]]; then
+    log_error "Plan file not found: $plan_file"
+    return 1
+  fi
+
+  if [[ ! -r "$plan_file" ]]; then
+    log_error "Plan file is not readable: $plan_file"
+    return 1
+  fi
+
+  log_info "Parsing plan data from $plan_file"
+
+  NEW_LANG=$(extract_plan_field "Language/Version" "$plan_file")
+  NEW_FRAMEWORK=$(extract_plan_field "Primary Dependencies" "$plan_file")
+  NEW_DB=$(extract_plan_field "Storage" "$plan_file")
+  NEW_PROJECT_TYPE=$(extract_plan_field "Project Type" "$plan_file")
+
+  # Log what we found
+  if [[ -n "$NEW_LANG" ]]; then
+    log_info "Found language: $NEW_LANG"
+  else
+    log_warning "No language information found in plan"
+  fi
+
+  if [[ -n "$NEW_FRAMEWORK" ]]; then
+    log_info "Found framework: $NEW_FRAMEWORK"
+  fi
+
+  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+    log_info "Found database: $NEW_DB"
+  fi
+
+  if [[ -n "$NEW_PROJECT_TYPE" ]]; then
+    log_info "Found project type: $NEW_PROJECT_TYPE"
+  fi
 }
 
 format_technology_stack() {
-    local lang="$1"
-    local framework="$2"
-    local parts=()
-    
-    # Add non-empty parts
-    [[ -n "$lang" && "$lang" != "NEEDS CLARIFICATION" ]] && parts+=("$lang")
-    [[ -n "$framework" && "$framework" != "NEEDS CLARIFICATION" && "$framework" != "N/A" ]] && parts+=("$framework")
-    
-    # Join with proper formatting
-    if [[ ${#parts[@]} -eq 0 ]]; then
-        echo ""
-    elif [[ ${#parts[@]} -eq 1 ]]; then
-        echo "${parts[0]}"
-    else
-        # Join multiple parts with " + "
-        local result="${parts[0]}"
-        for ((i=1; i<${#parts[@]}; i++)); do
-            result="$result + ${parts[i]}"
-        done
-        echo "$result"
-    fi
+  local lang="$1"
+  local framework="$2"
+  local parts=()
+
+  # Add non-empty parts
+  [[ -n "$lang" && "$lang" != "NEEDS CLARIFICATION" ]] && parts+=("$lang")
+  [[ -n "$framework" && "$framework" != "NEEDS CLARIFICATION" && "$framework" != "N/A" ]] && parts+=("$framework")
+
+  # Join with proper formatting
+  if [[ ${#parts[@]} -eq 0 ]]; then
+    echo ""
+  elif [[ ${#parts[@]} -eq 1 ]]; then
+    echo "${parts[0]}"
+  else
+    # Join multiple parts with " + "
+    local result="${parts[0]}"
+    for ((i = 1; i < ${#parts[@]}; i++)); do
+      result="$result + ${parts[i]}"
+    done
+    echo "$result"
+  fi
 }
 
 #==============================================================================
@@ -230,315 +230,312 @@ format_technology_stack() {
 #==============================================================================
 
 get_project_structure() {
-    local project_type="$1"
-    
-    if [[ "$project_type" == *"web"* ]]; then
-        echo "backend/\\nfrontend/\\ntests/"
-    else
-        echo "src/\\ntests/"
-    fi
+  local project_type="$1"
+
+  if [[ "$project_type" == *"web"* ]]; then
+    echo "backend/\\nfrontend/\\ntests/"
+  else
+    echo "src/\\ntests/"
+  fi
 }
 
 get_commands_for_language() {
-    local lang="$1"
-    
-    case "$lang" in
-        *"Python"*)
-            echo "cd src && pytest && ruff check ."
-            ;;
-        *"Rust"*)
-            echo "cargo test && cargo clippy"
-            ;;
-        *"JavaScript"*|*"TypeScript"*)
-            echo "npm test \\&\\& npm run lint"
-            ;;
-        *)
-            echo "# Add commands for $lang"
-            ;;
-    esac
+  local lang="$1"
+
+  case "$lang" in
+    *"Python"*)
+      echo "cd src && pytest && ruff check ."
+      ;;
+    *"Rust"*)
+      echo "cargo test && cargo clippy"
+      ;;
+    *"JavaScript"* | *"TypeScript"*)
+      echo "npm test \\&\\& npm run lint"
+      ;;
+    *)
+      echo "# Add commands for $lang"
+      ;;
+  esac
 }
 
 get_language_conventions() {
-    local lang="$1"
-    echo "$lang: Follow standard conventions"
+  local lang="$1"
+  echo "$lang: Follow standard conventions"
 }
 
 create_new_agent_file() {
-    local target_file="$1"
-    local temp_file="$2"
-    local project_name="$3"
-    local current_date="$4"
-    
-    if [[ ! -f "$TEMPLATE_FILE" ]]; then
-        log_error "Template not found at $TEMPLATE_FILE"
-        return 1
-    fi
-    
-    if [[ ! -r "$TEMPLATE_FILE" ]]; then
-        log_error "Template file is not readable: $TEMPLATE_FILE"
-        return 1
-    fi
-    
-    log_info "Creating new agent context file from template..."
-    
-    if ! cp "$TEMPLATE_FILE" "$temp_file"; then
-        log_error "Failed to copy template file"
-        return 1
-    fi
-    
-    # Replace template placeholders
-    local project_structure
-    project_structure=$(get_project_structure "$NEW_PROJECT_TYPE")
-    
-    local commands
-    commands=$(get_commands_for_language "$NEW_LANG")
-    
-    local language_conventions
-    language_conventions=$(get_language_conventions "$NEW_LANG")
-    
-    # Perform substitutions with error checking using safer approach
-    # Escape special characters for sed by using a different delimiter or escaping
-    local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-    local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-    local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-    
-    # Build technology stack and recent change strings conditionally
-    local tech_stack
-    if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
-        tech_stack="- $escaped_lang + $escaped_framework ($escaped_branch)"
-    elif [[ -n "$escaped_lang" ]]; then
-        tech_stack="- $escaped_lang ($escaped_branch)"
-    elif [[ -n "$escaped_framework" ]]; then
-        tech_stack="- $escaped_framework ($escaped_branch)"
-    else
-        tech_stack="- ($escaped_branch)"
-    fi
+  local target_file="$1"
+  local temp_file="$2"
+  local project_name="$3"
+  local current_date="$4"
 
-    local recent_change
-    if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_lang + $escaped_framework"
-    elif [[ -n "$escaped_lang" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_lang"
-    elif [[ -n "$escaped_framework" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_framework"
-    else
-        recent_change="- $escaped_branch: Added"
-    fi
+  if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    log_error "Template not found at $TEMPLATE_FILE"
+    return 1
+  fi
 
-    local substitutions=(
-        "s|\[PROJECT NAME\]|$project_name|"
-        "s|\[DATE\]|$current_date|"
-        "s|\[EXTRACTED FROM ALL PLAN.MD FILES\]|$tech_stack|"
-        "s|\[ACTUAL STRUCTURE FROM PLANS\]|$project_structure|g"
-        "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$commands|"
-        "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
-        "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
-    )
-    
-    for substitution in "${substitutions[@]}"; do
-        if ! sed -i.bak -e "$substitution" "$temp_file"; then
-            log_error "Failed to perform substitution: $substitution"
-            rm -f "$temp_file" "$temp_file.bak"
-            return 1
-        fi
-    done
-    
-    # Convert \n sequences to actual newlines
-    newline=$(printf '\n')
-    sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
-    
-    # Clean up backup files
-    rm -f "$temp_file.bak" "$temp_file.bak2"
-    
-    return 0
+  if [[ ! -r "$TEMPLATE_FILE" ]]; then
+    log_error "Template file is not readable: $TEMPLATE_FILE"
+    return 1
+  fi
+
+  log_info "Creating new agent context file from template..."
+
+  if ! cp "$TEMPLATE_FILE" "$temp_file"; then
+    log_error "Failed to copy template file"
+    return 1
+  fi
+
+  # Replace template placeholders
+  local project_structure
+  project_structure=$(get_project_structure "$NEW_PROJECT_TYPE")
+
+  local commands
+  commands=$(get_commands_for_language "$NEW_LANG")
+
+  local language_conventions
+  language_conventions=$(get_language_conventions "$NEW_LANG")
+
+  # Perform substitutions with error checking using safer approach
+  # Escape special characters for sed by using a different delimiter or escaping
+  local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+  local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+  local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+
+  # Build technology stack and recent change strings conditionally
+  local tech_stack
+  if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
+    tech_stack="- $escaped_lang + $escaped_framework ($escaped_branch)"
+  elif [[ -n "$escaped_lang" ]]; then
+    tech_stack="- $escaped_lang ($escaped_branch)"
+  elif [[ -n "$escaped_framework" ]]; then
+    tech_stack="- $escaped_framework ($escaped_branch)"
+  else
+    tech_stack="- ($escaped_branch)"
+  fi
+
+  local recent_change
+  if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
+    recent_change="- $escaped_branch: Added $escaped_lang + $escaped_framework"
+  elif [[ -n "$escaped_lang" ]]; then
+    recent_change="- $escaped_branch: Added $escaped_lang"
+  elif [[ -n "$escaped_framework" ]]; then
+    recent_change="- $escaped_branch: Added $escaped_framework"
+  else
+    recent_change="- $escaped_branch: Added"
+  fi
+
+  local substitutions=(
+    "s|\[PROJECT NAME\]|$project_name|"
+    "s|\[DATE\]|$current_date|"
+    "s|\[EXTRACTED FROM ALL PLAN.MD FILES\]|$tech_stack|"
+    "s|\[ACTUAL STRUCTURE FROM PLANS\]|$project_structure|g"
+    "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$commands|"
+    "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
+    "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
+  )
+
+  for substitution in "${substitutions[@]}"; do
+    if ! sed -i.bak -e "$substitution" "$temp_file"; then
+      log_error "Failed to perform substitution: $substitution"
+      rm -f "$temp_file" "$temp_file.bak"
+      return 1
+    fi
+  done
+
+  # Convert \n sequences to actual newlines
+  newline=$(printf '\n')
+  sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
+
+  # Clean up backup files
+  rm -f "$temp_file.bak" "$temp_file.bak2"
+
+  return 0
 }
 
-
-
-
 update_existing_agent_file() {
-    local target_file="$1"
-    local current_date="$2"
-    
-    log_info "Updating existing agent context file..."
-    
-    # Use a single temporary file for atomic update
-    local temp_file
-    temp_file=$(mktemp) || {
-        log_error "Failed to create temporary file"
-        return 1
-    }
-    
-    # Process the file in one pass
-    local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
-    local new_tech_entries=()
-    local new_change_entry=""
-    
-    # Prepare new technology entries
-    if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
-        new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
+  local target_file="$1"
+  local current_date="$2"
+
+  log_info "Updating existing agent context file..."
+
+  # Use a single temporary file for atomic update
+  local temp_file
+  temp_file=$(mktemp) || {
+    log_error "Failed to create temporary file"
+    return 1
+  }
+
+  # Process the file in one pass
+  local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
+  local new_tech_entries=()
+  local new_change_entry=""
+
+  # Prepare new technology entries
+  if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
+    new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
+  fi
+
+  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
+    new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
+  fi
+
+  # Prepare new change entry
+  if [[ -n "$tech_stack" ]]; then
+    new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
+  elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
+    new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
+  fi
+
+  # Process file line by line
+  local in_tech_section=false
+  local in_changes_section=false
+  local tech_entries_added=false
+  local changes_entries_added=false
+  local existing_changes_count=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Handle Active Technologies section
+    if [[ "$line" == "## Active Technologies" ]]; then
+      echo "$line" >>"$temp_file"
+      in_tech_section=true
+      continue
+    elif [[ $in_tech_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
+      # Add new tech entries before closing the section
+      if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
+        tech_entries_added=true
+      fi
+      echo "$line" >>"$temp_file"
+      in_tech_section=false
+      continue
+    elif [[ $in_tech_section == true ]] && [[ -z "$line" ]]; then
+      # Add new tech entries before empty line in tech section
+      if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
+        tech_entries_added=true
+      fi
+      echo "$line" >>"$temp_file"
+      continue
     fi
-    
-    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
-        new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
+
+    # Handle Recent Changes section
+    if [[ "$line" == "## Recent Changes" ]]; then
+      echo "$line" >>"$temp_file"
+      # Add new change entry right after the heading
+      if [[ -n "$new_change_entry" ]]; then
+        echo "$new_change_entry" >>"$temp_file"
+      fi
+      in_changes_section=true
+      changes_entries_added=true
+      continue
+    elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
+      echo "$line" >>"$temp_file"
+      in_changes_section=false
+      continue
+    elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
+      # Keep only first 2 existing changes
+      if [[ $existing_changes_count -lt 2 ]]; then
+        echo "$line" >>"$temp_file"
+        ((existing_changes_count++))
+      fi
+      continue
     fi
-    
-    # Prepare new change entry
-    if [[ -n "$tech_stack" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
-    elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
+
+    # Update timestamp
+    if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
+      echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >>"$temp_file"
+    else
+      echo "$line" >>"$temp_file"
     fi
-    
-    # Process file line by line
-    local in_tech_section=false
-    local in_changes_section=false
-    local tech_entries_added=false
-    local changes_entries_added=false
-    local existing_changes_count=0
-    
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        # Handle Active Technologies section
-        if [[ "$line" == "## Active Technologies" ]]; then
-            echo "$line" >> "$temp_file"
-            in_tech_section=true
-            continue
-        elif [[ $in_tech_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-            # Add new tech entries before closing the section
-            if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
-                tech_entries_added=true
-            fi
-            echo "$line" >> "$temp_file"
-            in_tech_section=false
-            continue
-        elif [[ $in_tech_section == true ]] && [[ -z "$line" ]]; then
-            # Add new tech entries before empty line in tech section
-            if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
-                tech_entries_added=true
-            fi
-            echo "$line" >> "$temp_file"
-            continue
-        fi
-        
-        # Handle Recent Changes section
-        if [[ "$line" == "## Recent Changes" ]]; then
-            echo "$line" >> "$temp_file"
-            # Add new change entry right after the heading
-            if [[ -n "$new_change_entry" ]]; then
-                echo "$new_change_entry" >> "$temp_file"
-            fi
-            in_changes_section=true
-            changes_entries_added=true
-            continue
-        elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-            echo "$line" >> "$temp_file"
-            in_changes_section=false
-            continue
-        elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
-            # Keep only first 2 existing changes
-            if [[ $existing_changes_count -lt 2 ]]; then
-                echo "$line" >> "$temp_file"
-                ((existing_changes_count++))
-            fi
-            continue
-        fi
-        
-        # Update timestamp
-        if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
-            echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
-        else
-            echo "$line" >> "$temp_file"
-        fi
-    done < "$target_file"
-    
-    # Post-loop check: if we're still in the Active Technologies section and haven't added new entries
-    if [[ $in_tech_section == true ]] && [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-        printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
-    fi
-    
-    # Move temp file to target atomically
-    if ! mv "$temp_file" "$target_file"; then
-        log_error "Failed to update target file"
-        rm -f "$temp_file"
-        return 1
-    fi
-    
-    return 0
+  done <"$target_file"
+
+  # Post-loop check: if we're still in the Active Technologies section and haven't added new entries
+  if [[ $in_tech_section == true ]] && [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+    printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
+  fi
+
+  # Move temp file to target atomically
+  if ! mv "$temp_file" "$target_file"; then
+    log_error "Failed to update target file"
+    rm -f "$temp_file"
+    return 1
+  fi
+
+  return 0
 }
 #==============================================================================
 # Main Agent File Update Function
 #==============================================================================
 
 update_agent_file() {
-    local target_file="$1"
-    local agent_name="$2"
-    
-    if [[ -z "$target_file" ]] || [[ -z "$agent_name" ]]; then
-        log_error "update_agent_file requires target_file and agent_name parameters"
+  local target_file="$1"
+  local agent_name="$2"
+
+  if [[ -z "$target_file" ]] || [[ -z "$agent_name" ]]; then
+    log_error "update_agent_file requires target_file and agent_name parameters"
+    return 1
+  fi
+
+  log_info "Updating $agent_name context file: $target_file"
+
+  local project_name
+  project_name=$(basename "$REPO_ROOT")
+  local current_date
+  current_date=$(date +%Y-%m-%d)
+
+  # Create directory if it doesn't exist
+  local target_dir
+  target_dir=$(dirname "$target_file")
+  if [[ ! -d "$target_dir" ]]; then
+    if ! mkdir -p "$target_dir"; then
+      log_error "Failed to create directory: $target_dir"
+      return 1
+    fi
+  fi
+
+  if [[ ! -f "$target_file" ]]; then
+    # Create new file from template
+    local temp_file
+    temp_file=$(mktemp) || {
+      log_error "Failed to create temporary file"
+      return 1
+    }
+
+    if create_new_agent_file "$target_file" "$temp_file" "$project_name" "$current_date"; then
+      if mv "$temp_file" "$target_file"; then
+        log_success "Created new $agent_name context file"
+      else
+        log_error "Failed to move temporary file to $target_file"
+        rm -f "$temp_file"
         return 1
-    fi
-    
-    log_info "Updating $agent_name context file: $target_file"
-    
-    local project_name
-    project_name=$(basename "$REPO_ROOT")
-    local current_date
-    current_date=$(date +%Y-%m-%d)
-    
-    # Create directory if it doesn't exist
-    local target_dir
-    target_dir=$(dirname "$target_file")
-    if [[ ! -d "$target_dir" ]]; then
-        if ! mkdir -p "$target_dir"; then
-            log_error "Failed to create directory: $target_dir"
-            return 1
-        fi
-    fi
-    
-    if [[ ! -f "$target_file" ]]; then
-        # Create new file from template
-        local temp_file
-        temp_file=$(mktemp) || {
-            log_error "Failed to create temporary file"
-            return 1
-        }
-        
-        if create_new_agent_file "$target_file" "$temp_file" "$project_name" "$current_date"; then
-            if mv "$temp_file" "$target_file"; then
-                log_success "Created new $agent_name context file"
-            else
-                log_error "Failed to move temporary file to $target_file"
-                rm -f "$temp_file"
-                return 1
-            fi
-        else
-            log_error "Failed to create new agent file"
-            rm -f "$temp_file"
-            return 1
-        fi
+      fi
     else
-        # Update existing file
-        if [[ ! -r "$target_file" ]]; then
-            log_error "Cannot read existing file: $target_file"
-            return 1
-        fi
-        
-        if [[ ! -w "$target_file" ]]; then
-            log_error "Cannot write to existing file: $target_file"
-            return 1
-        fi
-        
-        if update_existing_agent_file "$target_file" "$current_date"; then
-            log_success "Updated existing $agent_name context file"
-        else
-            log_error "Failed to update existing agent file"
-            return 1
-        fi
+      log_error "Failed to create new agent file"
+      rm -f "$temp_file"
+      return 1
     fi
-    
-    return 0
+  else
+    # Update existing file
+    if [[ ! -r "$target_file" ]]; then
+      log_error "Cannot read existing file: $target_file"
+      return 1
+    fi
+
+    if [[ ! -w "$target_file" ]]; then
+      log_error "Cannot write to existing file: $target_file"
+      return 1
+    fi
+
+    if update_existing_agent_file "$target_file" "$current_date"; then
+      log_success "Updated existing $agent_name context file"
+    else
+      log_error "Failed to update existing agent file"
+      return 1
+    fi
+  fi
+
+  return 0
 }
 
 #==============================================================================
@@ -546,145 +543,145 @@ update_agent_file() {
 #==============================================================================
 
 update_specific_agent() {
-    local agent_type="$1"
-    
-    case "$agent_type" in
-        claude)
-            update_agent_file "$CLAUDE_FILE" "Claude Code"
-            ;;
-        gemini)
-            update_agent_file "$GEMINI_FILE" "Gemini CLI"
-            ;;
-        copilot)
-            update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-            ;;
-        cursor-agent)
-            update_agent_file "$CURSOR_FILE" "Cursor IDE"
-            ;;
-        qwen)
-            update_agent_file "$QWEN_FILE" "Qwen Code"
-            ;;
-        opencode)
-            update_agent_file "$AGENTS_FILE" "opencode"
-            ;;
-        codex)
-            update_agent_file "$AGENTS_FILE" "Codex CLI"
-            ;;
-        windsurf)
-            update_agent_file "$WINDSURF_FILE" "Windsurf"
-            ;;
-        kilocode)
-            update_agent_file "$KILOCODE_FILE" "Kilo Code"
-            ;;
-        auggie)
-            update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-            ;;
-        roo)
-            update_agent_file "$ROO_FILE" "Roo Code"
-            ;;
-        codebuddy)
-            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-            ;;
-        q)
-            update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-            ;;
-        *)
-            log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|q"
-            exit 1
-            ;;
-    esac
+  local agent_type="$1"
+
+  case "$agent_type" in
+    claude)
+      update_agent_file "$CLAUDE_FILE" "Claude Code"
+      ;;
+    gemini)
+      update_agent_file "$GEMINI_FILE" "Gemini CLI"
+      ;;
+    copilot)
+      update_agent_file "$COPILOT_FILE" "GitHub Copilot"
+      ;;
+    cursor-agent)
+      update_agent_file "$CURSOR_FILE" "Cursor IDE"
+      ;;
+    qwen)
+      update_agent_file "$QWEN_FILE" "Qwen Code"
+      ;;
+    opencode)
+      update_agent_file "$AGENTS_FILE" "opencode"
+      ;;
+    codex)
+      update_agent_file "$AGENTS_FILE" "Codex CLI"
+      ;;
+    windsurf)
+      update_agent_file "$WINDSURF_FILE" "Windsurf"
+      ;;
+    kilocode)
+      update_agent_file "$KILOCODE_FILE" "Kilo Code"
+      ;;
+    auggie)
+      update_agent_file "$AUGGIE_FILE" "Auggie CLI"
+      ;;
+    roo)
+      update_agent_file "$ROO_FILE" "Roo Code"
+      ;;
+    codebuddy)
+      update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
+      ;;
+    q)
+      update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
+      ;;
+    *)
+      log_error "Unknown agent type '$agent_type'"
+      log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|q"
+      exit 1
+      ;;
+  esac
 }
 
 update_all_existing_agents() {
-    local found_agent=false
-    
-    # Check each possible agent file and update if it exists
-    if [[ -f "$CLAUDE_FILE" ]]; then
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$GEMINI_FILE" ]]; then
-        update_agent_file "$GEMINI_FILE" "Gemini CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$COPILOT_FILE" ]]; then
-        update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-        found_agent=true
-    fi
-    
-    if [[ -f "$CURSOR_FILE" ]]; then
-        update_agent_file "$CURSOR_FILE" "Cursor IDE"
-        found_agent=true
-    fi
-    
-    if [[ -f "$QWEN_FILE" ]]; then
-        update_agent_file "$QWEN_FILE" "Qwen Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$AGENTS_FILE" ]]; then
-        update_agent_file "$AGENTS_FILE" "Codex/opencode"
-        found_agent=true
-    fi
-    
-    if [[ -f "$WINDSURF_FILE" ]]; then
-        update_agent_file "$WINDSURF_FILE" "Windsurf"
-        found_agent=true
-    fi
-    
-    if [[ -f "$KILOCODE_FILE" ]]; then
-        update_agent_file "$KILOCODE_FILE" "Kilo Code"
-        found_agent=true
-    fi
+  local found_agent=false
 
-    if [[ -f "$AUGGIE_FILE" ]]; then
-        update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$ROO_FILE" ]]; then
-        update_agent_file "$ROO_FILE" "Roo Code"
-        found_agent=true
-    fi
+  # Check each possible agent file and update if it exists
+  if [[ -f "$CLAUDE_FILE" ]]; then
+    update_agent_file "$CLAUDE_FILE" "Claude Code"
+    found_agent=true
+  fi
 
-    if [[ -f "$CODEBUDDY_FILE" ]]; then
-        update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-        found_agent=true
-    fi
+  if [[ -f "$GEMINI_FILE" ]]; then
+    update_agent_file "$GEMINI_FILE" "Gemini CLI"
+    found_agent=true
+  fi
 
-    if [[ -f "$Q_FILE" ]]; then
-        update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-        found_agent=true
-    fi
-    
-    # If no agent files exist, create a default Claude file
-    if [[ "$found_agent" == false ]]; then
-        log_info "No existing agent files found, creating default Claude file..."
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
-    fi
+  if [[ -f "$COPILOT_FILE" ]]; then
+    update_agent_file "$COPILOT_FILE" "GitHub Copilot"
+    found_agent=true
+  fi
+
+  if [[ -f "$CURSOR_FILE" ]]; then
+    update_agent_file "$CURSOR_FILE" "Cursor IDE"
+    found_agent=true
+  fi
+
+  if [[ -f "$QWEN_FILE" ]]; then
+    update_agent_file "$QWEN_FILE" "Qwen Code"
+    found_agent=true
+  fi
+
+  if [[ -f "$AGENTS_FILE" ]]; then
+    update_agent_file "$AGENTS_FILE" "Codex/opencode"
+    found_agent=true
+  fi
+
+  if [[ -f "$WINDSURF_FILE" ]]; then
+    update_agent_file "$WINDSURF_FILE" "Windsurf"
+    found_agent=true
+  fi
+
+  if [[ -f "$KILOCODE_FILE" ]]; then
+    update_agent_file "$KILOCODE_FILE" "Kilo Code"
+    found_agent=true
+  fi
+
+  if [[ -f "$AUGGIE_FILE" ]]; then
+    update_agent_file "$AUGGIE_FILE" "Auggie CLI"
+    found_agent=true
+  fi
+
+  if [[ -f "$ROO_FILE" ]]; then
+    update_agent_file "$ROO_FILE" "Roo Code"
+    found_agent=true
+  fi
+
+  if [[ -f "$CODEBUDDY_FILE" ]]; then
+    update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
+    found_agent=true
+  fi
+
+  if [[ -f "$Q_FILE" ]]; then
+    update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
+    found_agent=true
+  fi
+
+  # If no agent files exist, create a default Claude file
+  if [[ "$found_agent" == false ]]; then
+    log_info "No existing agent files found, creating default Claude file..."
+    update_agent_file "$CLAUDE_FILE" "Claude Code"
+  fi
 }
 print_summary() {
-    echo
-    log_info "Summary of changes:"
-    
-    if [[ -n "$NEW_LANG" ]]; then
-        echo "  - Added language: $NEW_LANG"
-    fi
-    
-    if [[ -n "$NEW_FRAMEWORK" ]]; then
-        echo "  - Added framework: $NEW_FRAMEWORK"
-    fi
-    
-    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
-        echo "  - Added database: $NEW_DB"
-    fi
-    
-    echo
+  echo
+  log_info "Summary of changes:"
 
-    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|q]"
+  if [[ -n "$NEW_LANG" ]]; then
+    echo "  - Added language: $NEW_LANG"
+  fi
+
+  if [[ -n "$NEW_FRAMEWORK" ]]; then
+    echo "  - Added framework: $NEW_FRAMEWORK"
+  fi
+
+  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+    echo "  - Added database: $NEW_DB"
+  fi
+
+  echo
+
+  log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|q]"
 }
 
 #==============================================================================
@@ -692,48 +689,47 @@ print_summary() {
 #==============================================================================
 
 main() {
-    # Validate environment before proceeding
-    validate_environment
-    
-    log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
-    
-    # Parse the plan file to extract project information
-    if ! parse_plan_data "$NEW_PLAN"; then
-        log_error "Failed to parse plan data"
-        exit 1
+  # Validate environment before proceeding
+  validate_environment
+
+  log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
+
+  # Parse the plan file to extract project information
+  if ! parse_plan_data "$NEW_PLAN"; then
+    log_error "Failed to parse plan data"
+    exit 1
+  fi
+
+  # Process based on agent type argument
+  local success=true
+
+  if [[ -z "$AGENT_TYPE" ]]; then
+    # No specific agent provided - update all existing agent files
+    log_info "No agent specified, updating all existing agent files..."
+    if ! update_all_existing_agents; then
+      success=false
     fi
-    
-    # Process based on agent type argument
-    local success=true
-    
-    if [[ -z "$AGENT_TYPE" ]]; then
-        # No specific agent provided - update all existing agent files
-        log_info "No agent specified, updating all existing agent files..."
-        if ! update_all_existing_agents; then
-            success=false
-        fi
-    else
-        # Specific agent provided - update only that agent
-        log_info "Updating specific agent: $AGENT_TYPE"
-        if ! update_specific_agent "$AGENT_TYPE"; then
-            success=false
-        fi
+  else
+    # Specific agent provided - update only that agent
+    log_info "Updating specific agent: $AGENT_TYPE"
+    if ! update_specific_agent "$AGENT_TYPE"; then
+      success=false
     fi
-    
-    # Print summary
-    print_summary
-    
-    if [[ "$success" == true ]]; then
-        log_success "Agent context update completed successfully"
-        exit 0
-    else
-        log_error "Agent context update completed with errors"
-        exit 1
-    fi
+  fi
+
+  # Print summary
+  print_summary
+
+  if [[ "$success" == true ]]; then
+    log_success "Agent context update completed successfully"
+    exit 0
+  else
+    log_error "Agent context update completed with errors"
+    exit 1
+  fi
 }
 
 # Execute main function if script is run directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"
+  main "$@"
 fi
-

--- a/scripts/cleanup-orphaned-resources.sh
+++ b/scripts/cleanup-orphaned-resources.sh
@@ -27,30 +27,30 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 print_info() {
-    echo -e "${BLUE}ℹ️  $1${NC}"
+  echo -e "${BLUE}ℹ️  $1${NC}"
 }
 
 print_success() {
-    echo -e "${GREEN}✅ $1${NC}"
+  echo -e "${GREEN}✅ $1${NC}"
 }
 
 print_warning() {
-    echo -e "${YELLOW}⚠️  $1${NC}"
+  echo -e "${YELLOW}⚠️  $1${NC}"
 }
 
 print_error() {
-    echo -e "${RED}❌ $1${NC}"
+  echo -e "${RED}❌ $1${NC}"
 }
 
 # Check prerequisites
-if ! command -v az &> /dev/null; then
-    print_error "Azure CLI not found"
-    exit 1
+if ! command -v az &>/dev/null; then
+  print_error "Azure CLI not found"
+  exit 1
 fi
 
-if ! az account show &> /dev/null; then
-    print_error "Not logged in to Azure. Run: az login"
-    exit 1
+if ! az account show &>/dev/null; then
+  print_error "Not logged in to Azure. Run: az login"
+  exit 1
 fi
 
 # Arguments
@@ -58,8 +58,8 @@ MODE="${1:---dry-run}"
 RESOURCE_GROUP_PATTERN="${2:-xc-ce-}"
 
 if [ "$MODE" != "--dry-run" ] && [ "$MODE" != "--delete" ]; then
-    print_error "Invalid mode. Use --dry-run or --delete"
-    exit 1
+  print_error "Invalid mode. Use --dry-run or --delete"
+  exit 1
 fi
 
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
@@ -71,14 +71,14 @@ print_info "Mode: $MODE"
 echo ""
 
 if [ "$MODE" == "--delete" ]; then
-    print_warning "⚠️  DELETE MODE - Resources will be removed!"
-    echo ""
-    read -p "Continue? (yes/no): " -r
-    if [[ ! $REPLY =~ ^[Yy](es)?$ ]]; then
-        print_info "Cancelled by user"
-        exit 0
-    fi
-    echo ""
+  print_warning "⚠️  DELETE MODE - Resources will be removed!"
+  echo ""
+  read -p "Continue? (yes/no): " -r
+  if [[ ! $REPLY =~ ^[Yy](es)?$ ]]; then
+    print_info "Cancelled by user"
+    exit 0
+  fi
+  echo ""
 fi
 
 # Track orphaned resources
@@ -87,84 +87,84 @@ ORPHANED_COUNT=0
 # 1. Find orphaned network interfaces
 print_info "Checking for orphaned network interfaces..."
 ORPHANED_NICS=$(az network nic list \
-    --query "[?virtualMachine==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
-    -o tsv)
+  --query "[?virtualMachine==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
+  -o tsv)
 
 if [ -n "$ORPHANED_NICS" ]; then
-    while IFS=$'\t' read -r nic_name rg_name; do
-        ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
-        print_warning "Found orphaned NIC: $nic_name (RG: $rg_name)"
+  while IFS=$'\t' read -r nic_name rg_name; do
+    ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+    print_warning "Found orphaned NIC: $nic_name (RG: $rg_name)"
 
-        if [ "$MODE" == "--delete" ]; then
-            az network nic delete --name "$nic_name" --resource-group "$rg_name" --yes --no-wait
-            print_success "Deleted: $nic_name"
-        fi
-    done <<< "$ORPHANED_NICS"
+    if [ "$MODE" == "--delete" ]; then
+      az network nic delete --name "$nic_name" --resource-group "$rg_name" --yes --no-wait
+      print_success "Deleted: $nic_name"
+    fi
+  done <<<"$ORPHANED_NICS"
 else
-    print_success "No orphaned NICs found"
+  print_success "No orphaned NICs found"
 fi
 echo ""
 
 # 2. Find orphaned public IPs
 print_info "Checking for orphaned public IPs..."
 ORPHANED_IPS=$(az network public-ip list \
-    --query "[?ipConfiguration==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
-    -o tsv)
+  --query "[?ipConfiguration==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
+  -o tsv)
 
 if [ -n "$ORPHANED_IPS" ]; then
-    while IFS=$'\t' read -r ip_name rg_name; do
-        ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
-        print_warning "Found orphaned Public IP: $ip_name (RG: $rg_name)"
+  while IFS=$'\t' read -r ip_name rg_name; do
+    ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+    print_warning "Found orphaned Public IP: $ip_name (RG: $rg_name)"
 
-        if [ "$MODE" == "--delete" ]; then
-            az network public-ip delete --name "$ip_name" --resource-group "$rg_name" --yes --no-wait
-            print_success "Deleted: $ip_name"
-        fi
-    done <<< "$ORPHANED_IPS"
+    if [ "$MODE" == "--delete" ]; then
+      az network public-ip delete --name "$ip_name" --resource-group "$rg_name" --yes --no-wait
+      print_success "Deleted: $ip_name"
+    fi
+  done <<<"$ORPHANED_IPS"
 else
-    print_success "No orphaned Public IPs found"
+  print_success "No orphaned Public IPs found"
 fi
 echo ""
 
 # 3. Find unattached disks
 print_info "Checking for unattached managed disks..."
 ORPHANED_DISKS=$(az disk list \
-    --query "[?managedBy==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
-    -o tsv)
+  --query "[?managedBy==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
+  -o tsv)
 
 if [ -n "$ORPHANED_DISKS" ]; then
-    while IFS=$'\t' read -r disk_name rg_name; do
-        ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
-        print_warning "Found unattached disk: $disk_name (RG: $rg_name)"
+  while IFS=$'\t' read -r disk_name rg_name; do
+    ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+    print_warning "Found unattached disk: $disk_name (RG: $rg_name)"
 
-        if [ "$MODE" == "--delete" ]; then
-            az disk delete --name "$disk_name" --resource-group "$rg_name" --yes --no-wait
-            print_success "Deleted: $disk_name"
-        fi
-    done <<< "$ORPHANED_DISKS"
+    if [ "$MODE" == "--delete" ]; then
+      az disk delete --name "$disk_name" --resource-group "$rg_name" --yes --no-wait
+      print_success "Deleted: $disk_name"
+    fi
+  done <<<"$ORPHANED_DISKS"
 else
-    print_success "No unattached disks found"
+  print_success "No unattached disks found"
 fi
 echo ""
 
 # 4. Find orphaned NSGs
 print_info "Checking for orphaned network security groups..."
 ORPHANED_NSGS=$(az network nsg list \
-    --query "[?subnets==null && networkInterfaces==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
-    -o tsv)
+  --query "[?subnets==null && networkInterfaces==null && name contains '$RESOURCE_GROUP_PATTERN'].{Name:name, ResourceGroup:resourceGroup}" \
+  -o tsv)
 
 if [ -n "$ORPHANED_NSGS" ]; then
-    while IFS=$'\t' read -r nsg_name rg_name; do
-        ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
-        print_warning "Found orphaned NSG: $nsg_name (RG: $rg_name)"
+  while IFS=$'\t' read -r nsg_name rg_name; do
+    ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+    print_warning "Found orphaned NSG: $nsg_name (RG: $rg_name)"
 
-        if [ "$MODE" == "--delete" ]; then
-            az network nsg delete --name "$nsg_name" --resource-group "$rg_name" --yes --no-wait
-            print_success "Deleted: $nsg_name"
-        fi
-    done <<< "$ORPHANED_NSGS"
+    if [ "$MODE" == "--delete" ]; then
+      az network nsg delete --name "$nsg_name" --resource-group "$rg_name" --yes --no-wait
+      print_success "Deleted: $nsg_name"
+    fi
+  done <<<"$ORPHANED_NSGS"
 else
-    print_success "No orphaned NSGs found"
+  print_success "No orphaned NSGs found"
 fi
 echo ""
 
@@ -173,51 +173,51 @@ print_info "Checking for empty resource groups..."
 RESOURCE_GROUPS=$(az group list --query "[?name contains '$RESOURCE_GROUP_PATTERN'].name" -o tsv)
 
 for rg in $RESOURCE_GROUPS; do
-    RESOURCE_COUNT=$(az resource list --resource-group "$rg" --query "length(@)" -o tsv)
+  RESOURCE_COUNT=$(az resource list --resource-group "$rg" --query "length(@)" -o tsv)
 
-    if [ "$RESOURCE_COUNT" -eq 0 ]; then
-        ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
-        print_warning "Found empty resource group: $rg"
+  if [ "$RESOURCE_COUNT" -eq 0 ]; then
+    ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+    print_warning "Found empty resource group: $rg"
 
-        if [ "$MODE" == "--delete" ]; then
-            az group delete --name "$rg" --yes --no-wait
-            print_success "Deleted: $rg"
-        fi
+    if [ "$MODE" == "--delete" ]; then
+      az group delete --name "$rg" --yes --no-wait
+      print_success "Deleted: $rg"
     fi
+  fi
 done
 
 if [ -z "$RESOURCE_GROUPS" ]; then
-    print_success "No matching resource groups found"
+  print_success "No matching resource groups found"
 fi
 echo ""
 
 # Summary
 if [ "$MODE" == "--dry-run" ]; then
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "  Dry Run Summary"
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Dry Run Summary"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  if [ $ORPHANED_COUNT -gt 0 ]; then
+    print_warning "Found $ORPHANED_COUNT orphaned resource(s)"
     echo ""
-    if [ $ORPHANED_COUNT -gt 0 ]; then
-        print_warning "Found $ORPHANED_COUNT orphaned resource(s)"
-        echo ""
-        echo "To delete these resources, run:"
-        echo "  $0 --delete"
-    else
-        print_success "No orphaned resources found"
-    fi
+    echo "To delete these resources, run:"
+    echo "  $0 --delete"
+  else
+    print_success "No orphaned resources found"
+  fi
 else
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "  Cleanup Summary"
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Cleanup Summary"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  if [ $ORPHANED_COUNT -gt 0 ]; then
+    print_success "Deleted $ORPHANED_COUNT orphaned resource(s)"
     echo ""
-    if [ $ORPHANED_COUNT -gt 0 ]; then
-        print_success "Deleted $ORPHANED_COUNT orphaned resource(s)"
-        echo ""
-        echo "Note: Deletion operations are running asynchronously (--no-wait)"
-        echo "Check Azure Portal to verify completion"
-    else
-        print_success "No orphaned resources found"
-    fi
+    echo "Note: Deletion operations are running asynchronously (--no-wait)"
+    echo "Check Azure Portal to verify completion"
+  else
+    print_success "No orphaned resources found"
+  fi
 fi
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -25,30 +25,30 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 print_info() {
-    echo -e "${BLUE}ℹ️  $1${NC}"
+  echo -e "${BLUE}ℹ️  $1${NC}"
 }
 
 print_success() {
-    echo -e "${GREEN}✅ $1${NC}"
+  echo -e "${GREEN}✅ $1${NC}"
 }
 
 print_warning() {
-    echo -e "${YELLOW}⚠️  $1${NC}"
+  echo -e "${YELLOW}⚠️  $1${NC}"
 }
 
 print_error() {
-    echo -e "${RED}❌ $1${NC}"
+  echo -e "${RED}❌ $1${NC}"
 }
 
 # Check prerequisites
-if ! command -v az &> /dev/null; then
-    print_error "Azure CLI not found"
-    exit 1
+if ! command -v az &>/dev/null; then
+  print_error "Azure CLI not found"
+  exit 1
 fi
 
-if ! command -v terraform &> /dev/null; then
-    print_error "Terraform not found"
-    exit 1
+if ! command -v terraform &>/dev/null; then
+  print_error "Terraform not found"
+  exit 1
 fi
 
 # Arguments
@@ -56,8 +56,8 @@ ENVIRONMENT="${1:-dev}"
 TERRAFORM_DIR="terraform/environments/$ENVIRONMENT"
 
 if [ ! -d "$TERRAFORM_DIR" ]; then
-    print_error "Environment directory not found: $TERRAFORM_DIR"
-    exit 1
+  print_error "Environment directory not found: $TERRAFORM_DIR"
+  exit 1
 fi
 
 print_info "Validating deployment for environment: $ENVIRONMENT"
@@ -66,8 +66,8 @@ echo ""
 # Get Terraform outputs
 cd "$TERRAFORM_DIR"
 if [ ! -f "terraform.tfstate" ]; then
-    print_error "Terraform state file not found - run terraform apply first"
-    exit 1
+  print_error "Terraform state file not found - run terraform apply first"
+  exit 1
 fi
 
 print_info "Step 1/6: Retrieving Terraform outputs..."
@@ -76,8 +76,8 @@ SPOKE_VNET_ID=$(terraform output -raw spoke_vnet_id 2>/dev/null || echo "")
 RESOURCE_GROUP=$(terraform output -raw resource_group_name 2>/dev/null || echo "")
 
 if [ -z "$RESOURCE_GROUP" ]; then
-    print_error "Could not retrieve resource group from Terraform outputs"
-    exit 1
+  print_error "Could not retrieve resource group from Terraform outputs"
+  exit 1
 fi
 
 print_success "Terraform outputs retrieved"
@@ -85,97 +85,97 @@ echo ""
 
 # Validate Azure resources
 print_info "Step 2/6: Validating Azure resource group..."
-if az group show --name "$RESOURCE_GROUP" &> /dev/null; then
-    print_success "Resource group exists: $RESOURCE_GROUP"
+if az group show --name "$RESOURCE_GROUP" &>/dev/null; then
+  print_success "Resource group exists: $RESOURCE_GROUP"
 else
-    print_error "Resource group not found: $RESOURCE_GROUP"
-    exit 1
+  print_error "Resource group not found: $RESOURCE_GROUP"
+  exit 1
 fi
 echo ""
 
 print_info "Step 3/6: Validating virtual networks..."
 if [ -n "$HUB_VNET_ID" ]; then
-    if az network vnet show --ids "$HUB_VNET_ID" &> /dev/null; then
-        print_success "Hub VNET exists"
-    else
-        print_error "Hub VNET not found"
-        exit 1
-    fi
+  if az network vnet show --ids "$HUB_VNET_ID" &>/dev/null; then
+    print_success "Hub VNET exists"
+  else
+    print_error "Hub VNET not found"
+    exit 1
+  fi
 else
-    print_warning "Hub VNET ID not available - skipping validation"
+  print_warning "Hub VNET ID not available - skipping validation"
 fi
 
 if [ -n "$SPOKE_VNET_ID" ]; then
-    if az network vnet show --ids "$SPOKE_VNET_ID" &> /dev/null; then
-        print_success "Spoke VNET exists"
-    else
-        print_error "Spoke VNET not found"
-        exit 1
-    fi
+  if az network vnet show --ids "$SPOKE_VNET_ID" &>/dev/null; then
+    print_success "Spoke VNET exists"
+  else
+    print_error "Spoke VNET not found"
+    exit 1
+  fi
 else
-    print_warning "Spoke VNET ID not available - skipping validation"
+  print_warning "Spoke VNET ID not available - skipping validation"
 fi
 echo ""
 
 print_info "Step 4/6: Validating VNET peering..."
 if [ -n "$HUB_VNET_ID" ] && [ -n "$SPOKE_VNET_ID" ]; then
-    HUB_VNET_NAME=$(az network vnet show --ids "$HUB_VNET_ID" --query name -o tsv)
-    SPOKE_VNET_NAME=$(az network vnet show --ids "$SPOKE_VNET_ID" --query name -o tsv)
+  HUB_VNET_NAME=$(az network vnet show --ids "$HUB_VNET_ID" --query name -o tsv)
+  SPOKE_VNET_NAME=$(az network vnet show --ids "$SPOKE_VNET_ID" --query name -o tsv)
 
-    # Check hub-to-spoke peering
-    PEERING_STATE=$(az network vnet peering list \
-        --resource-group "$RESOURCE_GROUP" \
-        --vnet-name "$HUB_VNET_NAME" \
-        --query "[?remoteVirtualNetwork.id=='$SPOKE_VNET_ID'].peeringState" \
-        -o tsv)
+  # Check hub-to-spoke peering
+  PEERING_STATE=$(az network vnet peering list \
+    --resource-group "$RESOURCE_GROUP" \
+    --vnet-name "$HUB_VNET_NAME" \
+    --query "[?remoteVirtualNetwork.id=='$SPOKE_VNET_ID'].peeringState" \
+    -o tsv)
 
-    if [ "$PEERING_STATE" == "Connected" ]; then
-        print_success "VNET peering established"
-    else
-        print_error "VNET peering not established (state: $PEERING_STATE)"
-        exit 1
-    fi
+  if [ "$PEERING_STATE" == "Connected" ]; then
+    print_success "VNET peering established"
+  else
+    print_error "VNET peering not established (state: $PEERING_STATE)"
+    exit 1
+  fi
 else
-    print_warning "VNET IDs not available - skipping peering validation"
+  print_warning "VNET IDs not available - skipping peering validation"
 fi
 echo ""
 
 print_info "Step 5/6: Validating load balancer..."
 LB_NAME=$(az network lb list \
-    --resource-group "$RESOURCE_GROUP" \
-    --query "[0].name" \
-    -o tsv 2>/dev/null || echo "")
+  --resource-group "$RESOURCE_GROUP" \
+  --query "[0].name" \
+  -o tsv 2>/dev/null || echo "")
 
 if [ -n "$LB_NAME" ]; then
-    print_success "Load balancer found: $LB_NAME"
+  print_success "Load balancer found: $LB_NAME"
 
-    # Check health probes
-    PROBE_COUNT=$(az network lb probe list \
-        --resource-group "$RESOURCE_GROUP" \
-        --lb-name "$LB_NAME" \
-        --query "length(@)" \
-        -o tsv)
+  # Check health probes
+  PROBE_COUNT=$(az network lb probe list \
+    --resource-group "$RESOURCE_GROUP" \
+    --lb-name "$LB_NAME" \
+    --query "length(@)" \
+    -o tsv)
 
-    if [ "$PROBE_COUNT" -gt 0 ]; then
-        print_success "Health probes configured ($PROBE_COUNT probes)"
-    else
-        print_warning "No health probes found on load balancer"
-    fi
+  if [ "$PROBE_COUNT" -gt 0 ]; then
+    print_success "Health probes configured ($PROBE_COUNT probes)"
+  else
+    print_warning "No health probes found on load balancer"
+  fi
 
-    # Check backend pool
-    BACKEND_COUNT=$(az network lb address-pool list \
-        --resource-group "$RESOURCE_GROUP" \
-        --lb-name "$LB_NAME" \
-        --query "length(@)" \
-        -o tsv)
+  # Check backend pool
+  BACKEND_COUNT=$(az network lb address-pool list \
+    --resource-group "$RESOURCE_GROUP" \
+    --lb-name "$LB_NAME" \
+    --query "length(@)" \
+    -o tsv)
 
-    if [ "$BACKEND_COUNT" -gt 0 ]; then
-        print_success "Backend pools configured ($BACKEND_COUNT pools)"
-    else
-        print_warning "No backend pools found on load balancer"
-    fi
+  if [ "$BACKEND_COUNT" -gt 0 ]; then
+    print_success "Backend pools configured ($BACKEND_COUNT pools)"
+  else
+    print_warning "No backend pools found on load balancer"
+  fi
 else
-    print_warning "Load balancer not found - may not be deployed yet"
+  print_warning "Load balancer not found - may not be deployed yet"
 fi
 echo ""
 
@@ -183,11 +183,11 @@ print_info "Step 6/6: Validating F5 XC CE registration..."
 CE_SITE_NAME=$(terraform output -raw ce_site_name 2>/dev/null || echo "")
 
 if [ -n "$CE_SITE_NAME" ]; then
-    print_info "CE Site Name: $CE_SITE_NAME"
-    print_warning "F5 XC Console validation requires API access - check manually at:"
-    print_warning "https://<tenant>.console.ves.volterra.io/web/workspaces/distributed-apps/sites"
+  print_info "CE Site Name: $CE_SITE_NAME"
+  print_warning "F5 XC Console validation requires API access - check manually at:"
+  print_warning "https://<tenant>.console.ves.volterra.io/web/workspaces/distributed-apps/sites"
 else
-    print_warning "CE site name not available - skipping F5 XC validation"
+  print_warning "CE site name not available - skipping F5 XC validation"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
Fixes #45 - Apply consistent shell script formatting with shfmt

## Changes
Applied `shfmt -i 2 -ci -w` to all bash scripts:
- `scripts/cleanup-orphaned-resources.sh`
- `scripts/validate-deployment.sh`
- `.specify/scripts/bash/update-agent-context.sh`
- `.specify/scripts/bash/create-new-feature.sh`
- `.specify/scripts/bash/common.sh`

## Formatting Standards
- **2-space indentation**: Consistent throughout
- **Case indentation**: Proper case statement formatting
- **Uniform style**: All scripts follow same conventions

## Testing
- ✅ Pre-commit shfmt hook passes
- ✅ All scripts functionally unchanged
- ✅ Scripts execute correctly after formatting

## Files Changed
- 5 bash scripts (974 insertions, 979 deletions - mostly whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)