### PR TITLE
fix: replace deprecated AzureRM provider attributes

### DIFF
--- a/terraform/modules/azure-hub-vnet/main.tf
+++ b/terraform/modules/azure-hub-vnet/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_subnet" "nva" {
   address_prefixes     = [var.nva_subnet_prefix]
 
   # Disable private endpoint network policies for NVA subnet
-  private_endpoint_network_policies_enabled = false
+  private_endpoint_network_policies = "Disabled"
 }
 
 # T033: Management Subnet
@@ -161,7 +161,7 @@ resource "azurerm_route_table" "hub" {
   name                          = "${var.vnet_name}-rt"
   location                      = var.location
   resource_group_name           = var.resource_group_name
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 
   # Default route to internet (CE provides internet connectivity)
   route {

--- a/terraform/modules/azure-spoke-vnet/main.tf
+++ b/terraform/modules/azure-spoke-vnet/main.tf
@@ -128,7 +128,7 @@ resource "azurerm_route_table" "spoke" {
   name                          = "${var.vnet_name}-rt"
   location                      = var.location
   resource_group_name           = var.resource_group_name
-  disable_bgp_route_propagation = true # Disable BGP propagation for UDR
+  bgp_route_propagation_enabled = false # Disable BGP propagation for UDR
 
   # Default route to hub NVA (0.0.0.0/0 → hub NVA IP)
   route {


### PR DESCRIPTION
## Summary
Fixes #48 - Replace deprecated AzureRM provider attributes for v4.0 compatibility

## Changes

### 1. Private Endpoint Network Policies
**File**: `terraform/modules/azure-hub-vnet/main.tf:40`

**Old (deprecated)**:
```hcl
private_endpoint_network_policies_enabled = false
```

**New**:
```hcl
private_endpoint_network_policies = "Disabled"
```

### 2. BGP Route Propagation - Hub VNet
**File**: `terraform/modules/azure-hub-vnet/main.tf:164`

**Old (deprecated)**:
```hcl
disable_bgp_route_propagation = false
```

**New**:
```hcl
bgp_route_propagation_enabled = true
```

### 3. BGP Route Propagation - Spoke VNet
**File**: `terraform/modules/azure-spoke-vnet/main.tf:131`

**Old (deprecated)**:
```hcl
disable_bgp_route_propagation = true  # Disable BGP propagation for UDR
```

**New**:
```hcl
bgp_route_propagation_enabled = false  # Disable BGP propagation for UDR
```

## Root Cause
AzureRM provider deprecated these boolean attributes in favor of new naming conventions:
- `private_endpoint_network_policies_enabled` (bool) → `private_endpoint_network_policies` (string)
- `disable_bgp_route_propagation` (bool) → `bgp_route_propagation_enabled` (bool with inverted logic)

These deprecated attributes will be removed in AzureRM provider v4.0.

## Testing
- ✅ Terraform validate shows 0 deprecation warnings (after merging PR #52 and #54)
- ✅ Resource configurations remain functionally equivalent
- ✅ Ready for AzureRM provider v4.0 upgrade

## Dependencies
This PR works with:
- PR #52 - Fixes terraform output error
- PR #54 - Updates TFLint and pre-commit config

## Files Changed
- `terraform/modules/azure-hub-vnet/main.tf`
- `terraform/modules/azure-spoke-vnet/main.tf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)