### PR TITLE
fix: add backend block to dev environment for Azure state storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+# Backend configuration (environment-specific)
+backend.local.hcl
+!backend.local.hcl.example
+
 # Crash log files
 crash.log
 crash.*.log

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -1,6 +1,16 @@
 terraform {
   required_version = ">= 1.6.0"
 
+  # Azure Remote State Backend
+  # Configuration values provided via backend.local.hcl (manual CLI)
+  # or environment variables (GitHub Actions OIDC)
+  backend "azurerm" {
+    # Values set via:
+    # - backend.local.hcl: resource_group_name, storage_account_name, container_name, key
+    # - Environment variables: ARM_RESOURCE_GROUP_NAME, ARM_STORAGE_ACCOUNT_NAME, etc.
+    # - Authentication: Azure CLI (az login) or OIDC (ARM_USE_OIDC=true)
+  }
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Summary
Fixes #60 - Resolves the "Missing backend configuration" warning and ensures Terraform state is stored in Azure Blob Storage, not locally.

## Problem
After running `scripts/setup-backend.sh` and initializing Terraform with `terraform init -backend-config=backend.local.hcl`, users received a warning:
```
Warning: Missing backend configuration
-backend-config was used without a "backend" block in the configuration.
```

**Root Cause**: The `backend "azurerm"` block exists in `terraform/backend.tf` (parent directory), but Terraform was being run from `terraform/environments/dev/` (subdirectory). Without a backend block in the current directory, Terraform defaulted to **local backend** and ignored the backend.local.hcl file entirely.

## Testing Performed

### Before Fix
```bash
$ terraform init -backend-config=backend.local.hcl
⚠️  Warning: Missing backend configuration
⚠️  Defaulting to local backend
```
- State was stored locally (not in Azure)
- backend.local.hcl was ignored

### After Fix
```bash
$ terraform init -backend-config=backend.local.hcl -reconfigure
✅ Successfully configured the backend "azurerm"!
```
- ✅ No warnings during terraform init
- ✅ `.terraform/terraform.tfstate` shows `"type": "azurerm"`
- ✅ No local `terraform.tfstate` file (confirming remote storage)
- ✅ Backend configured with:
  - Storage Account: `tfstatermordasi8b09e96b`
  - Container: `rmordasiewicz-f5-xc-ce-terraform-tf`
  - Key: `dev/terraform.tfstate`

## Changes Made

1. **terraform/environments/dev/versions.tf**
   - Added `backend "azurerm"` block with documentation
   - Configuration values provided via `backend.local.hcl` or environment variables
   - Supports both Azure CLI auth (local) and OIDC (GitHub Actions)

2. **.gitignore**
   - Added `backend.local.hcl` to prevent committing environment-specific configuration
   - Allowed `backend.local.hcl.example` to remain in repository

## Verification Commands

```bash
cd terraform/environments/dev

# Reinitialize with Azure backend
terraform init -backend-config=backend.local.hcl -reconfigure

# Verify backend type
cat .terraform/terraform.tfstate | grep '"type"'
# Output: "type": "azurerm"

# Confirm no local state files
ls -la terraform.tfstate* 2>/dev/null || echo "✅ No local state files"
```

## Impact
- **Breaking**: Requires `terraform init -reconfigure` to migrate any existing local state to Azure
- **Benefit**: Ensures state is properly stored in Azure for team collaboration and CI/CD
- **Compatibility**: Works with both manual CLI workflow (Azure CLI auth) and GitHub Actions (OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)