### PR TITLE
feat: add workflow toggle for environments without Azure OIDC permissions

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   terraform-init:
     name: Initialize
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false'
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false'
     uses: ./.github/workflows/terraform-init.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -33,6 +35,8 @@ jobs:
 
   terraform-plan:
     name: Plan Changes
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false'
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false'
     needs: terraform-validate
     runs-on: ubuntu-latest
 
@@ -96,7 +100,8 @@ jobs:
   terraform-apply:
     name: Apply Infrastructure Changes
     needs: terraform-plan
-    if: needs.terraform-plan.outputs.has_changes == 'true'
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false' OR if no changes detected
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false' && needs.terraform-plan.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/terraform-init.yml
+++ b/.github/workflows/terraform-init.yml
@@ -32,6 +32,9 @@ on:
 jobs:
   terraform-init:
     name: Initialize Terraform
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false'
+    # Default behavior (variable not set) is to run the workflow
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   terraform-init:
     name: Initialize
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false'
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false'
     uses: ./.github/workflows/terraform-init.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -33,6 +35,8 @@ jobs:
 
   terraform-plan:
     name: Plan Infrastructure Changes
+    # Skip if ENABLE_AZURE_WORKFLOWS is explicitly set to 'false'
+    if: vars.ENABLE_AZURE_WORKFLOWS != 'false'
     needs: terraform-validate
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
Fixes #62 - Implements a GitHub repository variable (`ENABLE_AZURE_WORKFLOWS`) to control whether Azure-dependent workflows run, providing graceful handling for environments where Azure service principal role assignments cannot be configured.

## Problem Solved
When users lack permissions to assign Azure roles during `scripts/setup-backend.sh` execution:
- Service principal is created but lacks required roles
- GitHub Actions workflows fail with OIDC authentication errors
- All Terraform workflows (init, plan, apply) fail completely

## Solution Implemented

### 1. GitHub Repository Variable Toggle
**Variable**: `ENABLE_AZURE_WORKFLOWS`  
**Type**: Repository Variable (visible, not encrypted)  
**Values**:
- `true` - Enable Azure-dependent workflows (default when not set)
- `false` - Disable Azure-dependent workflows, keep validation only

### 2. Workflow Modifications

Added conditional `if: vars.ENABLE_AZURE_WORKFLOWS != 'false'` to:

**terraform-init.yml**:
- Entire `terraform-init` job skips when disabled

**terraform-plan.yml**:
- `terraform-init` job skips when disabled
- `terraform-plan` job skips when disabled
- `terraform-validate` job **always runs** (no Azure dependency)

**terraform-apply.yml**:
- `terraform-init` job skips when disabled
- `terraform-plan` job skips when disabled
- `terraform-apply` job skips when disabled

**Note**: Condition uses `!= 'false'` so default behavior (variable not set) is to run workflows (backward compatible).

### 3. setup-backend.sh Automation

The script now automatically configures the variable based on role assignment status:

```bash
if [ "$ROLES_ASSIGNED" = true ]; then
  # Set ENABLE_AZURE_WORKFLOWS=true (enable workflows)
elif [ "$ROLES_ASSIGNED" = false ]; then
  # Set ENABLE_AZURE_WORKFLOWS=false (disable workflows)
fi
```

**Output messaging**:
- ✅ When roles assigned: \"Enabled Azure workflows (ENABLE_AZURE_WORKFLOWS=true)\"
- ⚠️  When roles not assigned: \"Disabled Azure workflows (ENABLE_AZURE_WORKFLOWS=false)\"
- Provides manual override instructions in both cases

### 4. Summary Output Enhancement

**When workflows enabled** (roles assigned):
```
✅ GitHub Actions Workflows:
   • ENABLE_AZURE_WORKFLOWS=true (workflows enabled)
   • terraform-init, terraform-plan, terraform-apply will run with OIDC
```

**When workflows disabled** (roles not assigned):
```
⚠️  GitHub Actions Workflows:
   • ENABLE_AZURE_WORKFLOWS=false (Azure workflows disabled)
   • Reason: Service principal lacks required role assignments
   • Only terraform-validate will run in GitHub Actions
   • To enable after assigning roles:
     gh variable set ENABLE_AZURE_WORKFLOWS --body 'true' --repo owner/repo
```

## Testing Performed

### Variable Management
```bash
# Set variable to false
$ gh variable set ENABLE_AZURE_WORKFLOWS --body 'false' --repo robinmordasiewicz/f5-xc-ce-terraform
✅ Success

# Verify variable
$ gh variable list --repo robinmordasiewicz/f5-xc-ce-terraform
ENABLE_AZURE_WORKFLOWS	false	2025-10-22T20:07:09Z
```

### Code Validation
```bash
# YAML syntax validation
$ yamllint .github/workflows/terraform-*.yml
✅ All files valid

# Bash syntax validation  
$ shellcheck scripts/setup-backend.sh
✅ No issues found

# Pre-commit hooks
$ git commit
✅ All checks passed
```

## Benefits

1. ✅ **Non-destructive** - Workflows remain in repository, just skip when disabled
2. ✅ **Automatic detection** - setup-backend.sh configures based on permissions
3. ✅ **Manual override** - Users can toggle variable anytime via GitHub UI or CLI
4. ✅ **Backward compatible** - Default behavior (variable not set) = workflows run
5. ✅ **Graceful degradation** - Validation still runs, only Azure jobs skip
6. ✅ **Clear messaging** - Script output explains workflow status
7. ✅ **Easy re-enable** - Once roles assigned, simple command to enable

## Manual Commands Reference

```bash
# View current variable value
gh variable list --repo robinmordasiewicz/f5-xc-ce-terraform

# Disable Azure workflows
gh variable set ENABLE_AZURE_WORKFLOWS --body 'false' --repo robinmordasiewicz/f5-xc-ce-terraform

# Enable Azure workflows (after assigning roles)
gh variable set ENABLE_AZURE_WORKFLOWS --body 'true' --repo robinmordasiewicz/f5-xc-ce-terraform

# Delete variable (revert to default behavior)
gh variable delete ENABLE_AZURE_WORKFLOWS --repo robinmordasiewicz/f5-xc-ce-terraform
```

## Files Changed

- `.github/workflows/terraform-init.yml` (+3 lines)
- `.github/workflows/terraform-plan.yml` (+6 lines)
- `.github/workflows/terraform-apply.yml` (+9 lines)
- `scripts/setup-backend.sh` (+50 lines)

## Next Steps

After merge:
1. The variable is currently set to `false` for testing
2. Once Azure roles are assigned, update: `gh variable set ENABLE_AZURE_WORKFLOWS --body 'true'`
3. Workflows will automatically start running with OIDC authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)