### PR TITLE
feat: auto-generate SSH key pair for CE VMs

### DIFF
--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -97,6 +97,23 @@ output "default_route_next_hop" {
   value       = module.spoke_vnet.default_route_next_hop
 }
 
+# SSH Key Outputs
+output "ssh_key_generated" {
+  description = "Whether SSH key was auto-generated (true) or user-provided (false)"
+  value       = var.ssh_public_key == ""
+}
+
+output "ssh_private_key" {
+  description = "Auto-generated SSH private key for CE VM access (only if auto-generated)"
+  value       = var.ssh_public_key == "" ? tls_private_key.ce_ssh[0].private_key_openssh : "User provided their own SSH key"
+  sensitive   = true
+}
+
+output "ssh_connection_instructions" {
+  description = "Instructions for SSH access to CE VMs"
+  value       = var.ssh_public_key == "" ? "SSH key was auto-generated. To connect to CE VMs:\n\n1. Save the private key:\n   terraform output -raw ssh_private_key > ce_ssh_key.pem\n   chmod 600 ce_ssh_key.pem\n\n2. Connect to CE VM 1:\n   ssh -i ce_ssh_key.pem admin@${module.ce_appstack_1.public_ip}\n\n3. Connect to CE VM 2:\n   ssh -i ce_ssh_key.pem admin@${module.ce_appstack_2.public_ip}\n\nNote: The private key is also stored in the Terraform state file." : "Using user-provided SSH key. Use your own private key to connect."
+}
+
 # Summary Output
 output "deployment_summary" {
   description = "Deployment summary"
@@ -108,5 +125,6 @@ output "deployment_summary" {
     ce_site        = module.f5_xc_registration.site_name
     ce_instances   = [module.ce_appstack_1.vm_name, module.ce_appstack_2.vm_name]
     peering_status = module.spoke_vnet.peering_status
+    ssh_key_status = var.ssh_public_key == "" ? "auto-generated" : "user-provided"
   }
 }

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -88,8 +88,9 @@ variable "ce_vm_size" {
 }
 
 variable "ssh_public_key" {
-  description = "SSH public key for CE VM access"
+  description = "SSH public key for CE VM access (optional - will be auto-generated if not provided)"
   type        = string
+  default     = ""
 }
 
 # Tags

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -26,6 +26,11 @@ terraform {
       source  = "volterraedge/volterra"
       version = "~> 0.11"
     }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Implements automatic SSH key generation for CE VM deployment to eliminate manual prompts during `terraform plan` and enable fully automated CI/CD workflows.

## Changes Made
- ✅ Added TLS provider (~> 4.0) for SSH key generation
- ✅ Generate RSA 4096-bit key pair automatically if no SSH key is provided
- ✅ Made `ssh_public_key` variable optional with empty string default
- ✅ Added local variable to use either provided or generated SSH key
- ✅ Added outputs for SSH key retrieval and connection instructions
- ✅ Updated deployment summary to show SSH key status (auto-generated vs user-provided)

## Testing Performed
- ✅ `terraform init -upgrade` - Successfully initialized with TLS provider
- ✅ `terraform validate` - Configuration is valid
- ✅ `terraform plan` - Runs without prompting for SSH key
- ✅ Verified `tls_private_key.ce_ssh[0]` resource is created when no key is provided
- ✅ Pre-commit hooks passed (formatting, security scan, validation)

## Benefits
- ✅ Eliminates manual input during `terraform plan`
- ✅ Enables fully automated CI/CD pipelines
- ✅ Maintains backward compatibility with user-provided keys
- ✅ Provides clear instructions for SSH access to VMs
- ✅ Secure key storage in Terraform state with sensitive flag

## Usage Examples

### Auto-generated SSH Key (Default)
\`\`\`bash
terraform plan  # No SSH key prompt!
terraform apply

# Retrieve private key for SSH access
terraform output -raw ssh_private_key > ce_ssh_key.pem
chmod 600 ce_ssh_key.pem
ssh -i ce_ssh_key.pem admin@<ce-vm-ip>
\`\`\`

### User-provided SSH Key (Optional)
\`\`\`bash
terraform plan -var="ssh_public_key=$(cat ~/.ssh/id_rsa.pub)"
terraform apply -var="ssh_public_key=$(cat ~/.ssh/id_rsa.pub)"
\`\`\`

## Acceptance Criteria
- [x] `terraform plan` runs without prompting for SSH key
- [x] SSH key pair is automatically generated if not provided
- [x] Private key is stored securely with sensitive flag
- [x] Users can optionally provide their own SSH public key
- [x] Clear instructions provided for SSH access to CE VMs
- [x] No security regressions (private key properly marked sensitive)
- [x] All pre-commit checks pass

## Related Issues
Fixes #76

## Screenshots
N/A - Backend infrastructure change only

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)