### PR TITLE
fix: add pull-requests write permission to branch cleanup workflow

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   delete-merged-branch:


### PR DESCRIPTION
## Summary
Fixes the Branch Cleanup After Merge workflow by adding `pull-requests: write` permission, enabling the workflow to post cleanup reminder comments on merged PRs.

## Problem
The workflow was failing with error:
```
GraphQL: Resource not accessible by integration (addComment)
```

This occurred when trying to post helpful cleanup instructions to PRs after merge.

## Solution
Changed `pull-requests: read` to `pull-requests: write` in workflow permissions.

## Changes
- **File**: `.github/workflows/branch-cleanup.yml`
- **Change**: Updated permissions block (line 15)
- **Impact**: Workflow can now successfully post PR comments

## Testing
- ✅ Pre-commit checks passed
- ✅ YAML validation passed
- ✅ No Terraform files affected
- 🔄 Will be verified on merge

## Related
- Closes #78
- Fixes failures in runs since 2025-10-22
- No breaking changes to existing functionality

## Constitution Compliance
- ✅ Issue-first workflow followed
- ✅ Feature branch created with issue number
- ✅ Descriptive commit message with context
- ✅ Pre-commit validation passed