### PR TITLE
feat: include tenant ID in resource group naming for multi-tenant isolation

### DIFF
--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -261,7 +261,9 @@ fi
 
 # Configuration with improved naming to prevent conflicts
 # Azure resource group naming: alphanumeric + hyphens, max 90 chars
-RESOURCE_GROUP="${RESOURCE_GROUP:-${AZURE_USERNAME}-${GITHUB_REPO}-tfstate}"
+# Include tenant hash for multi-tenant isolation (8 chars, consistent with storage account pattern)
+TENANT_PREFIX=$(echo -n "$TENANT_ID" | md5sum | cut -c1-8)
+RESOURCE_GROUP="${RESOURCE_GROUP:-${AZURE_USERNAME}-${TENANT_PREFIX}-${GITHUB_REPO}-tfstate}"
 LOCATION="${LOCATION:-eastus}"
 # Storage account: lowercase alphanumeric only, 3-24 chars, globally unique
 # Format: tfstate + username_prefix(8) + unique_hash(8) = 23 chars total


### PR DESCRIPTION
## Summary
Enhances Azure resource group naming pattern to include tenant ID hash, providing multi-tenant isolation and preventing naming collisions when the same user/repository combination exists across different Azure tenants.

## Changes
- ✅ Added `TENANT_PREFIX` variable using 8-char MD5 hash of `TENANT_ID`
- ✅ Updated `RESOURCE_GROUP` pattern from `{username}-{repo}-tfstate` to `{username}-{tenant_hash}-{repo}-tfstate`
- ✅ Added inline documentation explaining multi-tenant isolation benefit
- ✅ Maintains Azure naming constraints (alphanumeric + hyphens, max 90 chars)
- ✅ Consistent with existing storage account naming methodology

## Benefits
- 🛡️ **Multi-tenant Isolation**: Resources clearly distinguished across different Azure tenants
- 🚫 **Collision Prevention**: Eliminates naming conflicts when same user works across multiple tenants
- 🔄 **Consistency**: Aligns with storage account naming pattern that already uses hashing
- 📊 **Traceability**: Improves resource ownership and governance visibility

## Technical Details
**Location**: `scripts/setup-backend.sh:265-266`

**Before**:
```bash
RESOURCE_GROUP="${RESOURCE_GROUP:-${AZURE_USERNAME}-${GITHUB_REPO}-tfstate}"
```

**After**:
```bash
TENANT_PREFIX=$(echo -n "$TENANT_ID" | md5sum | cut -c1-8)
RESOURCE_GROUP="${RESOURCE_GROUP:-${AZURE_USERNAME}-${TENANT_PREFIX}-${GITHUB_REPO}-tfstate}"
```

The `TENANT_ID` is already captured at line 248, and this implementation follows the same hashing pattern used for storage account naming (lines 269-273).

## Testing
- ✅ Bash syntax validation passed (`bash -n`)
- ✅ Shellcheck validation passed (no issues with new code)
- ✅ Pre-commit hooks passed (all checks successful)

## Backward Compatibility
Existing resource groups will not be renamed automatically. The new naming pattern will apply to:
- New deployments running `setup-backend.sh`
- Users who manually set `RESOURCE_GROUP` environment variable (unaffected)

## Closes
Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)