### PR TITLE
fix: export TF_VAR_resource_group_name in .env for CLI workflow

### DIFF
--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -141,6 +141,9 @@ export VES_P12_CONTENT="$VES_P12_CONTENT"
 export VES_P12_PASSWORD="$VES_P12_PASSWORD"
 export TF_VAR_f5_xc_tenant="$F5_XC_TENANT"
 
+# Azure Deployment Configuration
+export TF_VAR_resource_group_name="$RESOURCE_GROUP"
+
 # Alternative: Certificate and Key File Authentication
 # Uncomment these lines and comment out VES_P12_* variables above to use cert/key files:
 # export VOLT_API_CERT="$HOME/vescred.cert"
@@ -166,8 +169,8 @@ export TF_VAR_f5_xc_tenant="$F5_XC_TENANT"
 # Verification:
 #   • Check credentials are loaded: env | grep VOLT
 #   • Check credentials are loaded: env | grep VES_P12
-#   • Check Terraform variables: env | grep TF_VAR_f5_xc
-#   • Terraform should authenticate without prompts
+#   • Check Terraform variables: env | grep TF_VAR
+#   • Terraform should authenticate and plan without prompts
 ENV_FILE_CONTENT
   else
     cat >>"$env_file" <<ENV_FILE_CONTENT
@@ -176,6 +179,9 @@ export VOLT_API_URL="$VOLT_API_URL"
 export VOLT_API_KEY="$F5_XC_API_TOKEN"
 export TF_VAR_f5_xc_tenant="$F5_XC_TENANT"
 export TF_VAR_f5_xc_api_token="$F5_XC_API_TOKEN"
+
+# Azure Deployment Configuration
+export TF_VAR_resource_group_name="$RESOURCE_GROUP"
 
 # WARNING: The Terraform provider does NOT support API tokens!
 #          These credentials can only be used for direct API calls.


### PR DESCRIPTION
## Problem

Terraform plan prompts for `var.resource_group_name` during CLI workflow even though the setup script derives this value. This breaks the automated workflow and requires manual input.

## Solution

Export the derived resource group name as `TF_VAR_resource_group_name` in the `.env` file generated by `setup-backend.sh`.

## Changes

- **scripts/setup-backend.sh**: Add `TF_VAR_resource_group_name` export to `.env` generation
  - Applied to P12 certificate authentication branch
  - Applied to API token authentication branch
  - Updated verification instructions to check all TF_VAR variables

## Testing

✅ **Environment variable verification**:
```bash
source .env
env | grep TF_VAR_resource_group_name
# Output: TF_VAR_resource_group_name=rmordasiewicz-f5-xc-ce-terraform-tfstate
```

✅ **Terraform plan verification**:
```bash
terraform plan -input=false
# Successfully runs without prompting
# Resource group name correctly populated in plan output
```

## Benefits

- ✅ Eliminates manual input during `terraform plan`
- ✅ Aligns CLI workflow with CI/CD workflow patterns
- ✅ Maintains naming consistency between backend and deployment resource groups
- ✅ No breaking changes to existing workflows

## Validation

- Pre-commit hooks passed
- Shellcheck validation passed
- Terraform configuration valid
- End-to-end testing confirmed fix works

Closes #87

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)