### PR TITLE
fix: separate backend and infrastructure resource groups

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -83,6 +83,7 @@ jobs:
           VOLT_API_URL: ${{ secrets.VOLT_API_URL }}
           TF_VAR_f5_xc_api_token: ${{ secrets.F5_XC_API_TOKEN }}
           TF_VAR_f5_xc_tenant: ${{ secrets.F5_XC_TENANT }}
+          TF_VAR_resource_group_name: ${{ secrets.ARM_RESOURCE_GROUP_NAME }}
         run: |
           terraform plan -out=tfplan -detailed-exitcode || echo "exitcode=$?" >> $GITHUB_OUTPUT
           # Exit code 2 means changes detected, which is expected
@@ -157,6 +158,7 @@ jobs:
           VOLT_API_URL: ${{ secrets.VOLT_API_URL }}
           TF_VAR_f5_xc_api_token: ${{ secrets.F5_XC_API_TOKEN }}
           TF_VAR_f5_xc_tenant: ${{ secrets.F5_XC_TENANT }}
+          TF_VAR_resource_group_name: ${{ secrets.ARM_RESOURCE_GROUP_NAME }}
         run: |
           echo "## 🚀 Terraform Apply Started" >> $GITHUB_STEP_SUMMARY
           echo "**Time**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -97,6 +97,7 @@ jobs:
           VOLT_API_URL: ${{ secrets.VOLT_API_URL }}
           TF_VAR_f5_xc_api_token: ${{ secrets.F5_XC_API_TOKEN }}
           TF_VAR_f5_xc_tenant: ${{ secrets.F5_XC_TENANT }}
+          TF_VAR_resource_group_name: ${{ secrets.ARM_RESOURCE_GROUP_NAME }}
         run: |
           echo "## 🗑️ Terraform Destroy Plan" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -124,6 +125,7 @@ jobs:
           VOLT_API_URL: ${{ secrets.VOLT_API_URL }}
           TF_VAR_f5_xc_api_token: ${{ secrets.F5_XC_API_TOKEN }}
           TF_VAR_f5_xc_tenant: ${{ secrets.F5_XC_TENANT }}
+          TF_VAR_resource_group_name: ${{ secrets.ARM_RESOURCE_GROUP_NAME }}
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 💥 Destruction In Progress" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -80,6 +80,7 @@ jobs:
           VOLT_API_URL: ${{ secrets.VOLT_API_URL }}
           TF_VAR_f5_xc_api_token: ${{ secrets.F5_XC_API_TOKEN }}
           TF_VAR_f5_xc_tenant: ${{ secrets.F5_XC_TENANT }}
+          TF_VAR_resource_group_name: ${{ secrets.ARM_RESOURCE_GROUP_NAME }}
         run: |
           terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
           echo "exitcode=$?" >> $GITHUB_OUTPUT

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -11,9 +11,13 @@
 #
 # User Story 1 MVP: Initial CE deployment with hub-and-spoke and CI/CD
 
-# Azure Resource Group
+# Azure Resource Group for Infrastructure
+# NOTE: This is DIFFERENT from the backend storage resource group
+# - Backend RG: {username}-{tenant}-{repo}-tfstate (managed by setup-backend.sh, stores Terraform state)
+# - Infrastructure RG: {username}-{tenant}-{repo}-infra (managed by Terraform, holds CE/VNET/LB resources)
+# This separation prevents circular dependency where Terraform manages the RG storing its own state
 resource "azurerm_resource_group" "main" {
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}-infra"
   location = var.azure_region
 
   tags = var.tags


### PR DESCRIPTION
## Overview

Resolves architectural issue where Terraform attempted to manage the backend storage resource group, creating a circular dependency.

## Problem Statement

The original error occurred because:
1. Backend RG  exists (created by setup-backend.sh)
2. Terraform configuration tried to manage the same RG for infrastructure
3. This created circular dependency: Terraform managing the RG that stores its own state

## Solution: Option B - Separate Resource Groups

Implemented clean architectural separation following Terraform best practices:

| Purpose | Resource Group | Managed By | Contains |
|---------|---------------|------------|----------|
| **Backend** | `{name}-tfstate` | setup-backend.sh | Terraform state files |
| **Infrastructure** | `{name}-tfstate-infra` | Terraform | CE instances, VNETs, Load Balancers |

## Changes Made

### 1. Infrastructure Resource Group
**File**: `terraform/environments/dev/main.tf`
- Updated `azurerm_resource_group.main` to use `${var.resource_group_name}-infra`
- Added comprehensive documentation explaining the separation
- Result: Infrastructure RG is now distinct from backend storage RG

### 2. GitHub Actions Workflows
Added missing `TF_VAR_resource_group_name` environment variable to prevent input prompts:

**terraform-plan.yml**:
- Added to Terraform Plan step

**terraform-apply.yml**:
- Added to Terraform Plan step (line 86)
- Added to Terraform Apply step (line 161)

**terraform-destroy.yml**:
- Added to Terraform Destroy Plan step (line 100)
- Added to Terraform Destroy step (line 128)

## Benefits

✅ **No Circular Dependency**: Backend RG is completely independent from Terraform-managed resources
✅ **Safe Lifecycle Management**: Infrastructure can be destroyed without affecting state storage
✅ **Clear Separation of Concerns**: Backend storage is separate from infrastructure resources
✅ **Best Practices**: Aligns with Terraform's recommended architecture patterns
✅ **No Breaking Changes**: Existing workflows continue to function correctly

## Testing

### Local Verification
```bash
terraform plan
# Shows: azurerm_resource_group.main will be created
#        name = "rmordasiewicz-f5-xc-ce-terraform-tfstate-infra"
```

### GitHub Actions
- All workflows now have required `TF_VAR_resource_group_name` variable
- No manual input prompts during automated runs
- Backend initialization unchanged (still uses ARM_RESOURCE_GROUP_NAME)

## Risk Assessment

**Low Risk** - This change only affects resource group naming:
- Backend state storage: No changes
- GitHub Actions: Added missing variable (bug fix)
- Infrastructure RG: New naming convention (clean slate for new deployments)

## Related Issues

Closes #89

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>