### PR TITLE
fix: remove load balancer HA ports rule and F5 XC node_list

### DIFF
--- a/terraform/modules/f5-xc-registration/main.tf
+++ b/terraform/modules/f5-xc-registration/main.tf
@@ -33,47 +33,10 @@ resource "volterra_securemesh_site_v2" "ce_site" {
   }
 
   # Azure provider configuration
+  # NOTE: not_managed block without node_list - F5 XC auto-discovers nodes
+  # Nodes will register automatically using the site registration token
   azure {
-    not_managed {
-      node_list {
-        hostname = var.site_name
-
-        # Configure interface for Site Local Inside (SLI) network
-        interface_list {
-          # Use existing Azure VNET subnet
-          name        = "eth0"
-          description = "Inside network interface for hub VNET connectivity"
-
-          # Ethernet interface configuration
-          ethernet_interface {
-            device = "eth0"
-          }
-
-          # DHCP client for IP assignment
-          dhcp_client = true
-
-          # No IPv6 address
-          no_ipv6_address = true
-
-          # Network option: Site Local Inside (Local VRF)
-          network_option {
-            site_local_inside_network = true
-          }
-
-          # Enable site-to-site connectivity on this interface
-          site_to_site_connectivity_interface_enabled = true
-
-          # Interface priority
-          priority = 1
-
-          # Enable monitoring
-          monitor_disabled = false
-        }
-
-        # Node type
-        type = "Control"
-      }
-    }
+    not_managed {}
   }
 
   # Performance enhancement mode (L7 optimized)


### PR DESCRIPTION
## Summary
Critical module fixes for deployment errors discovered during end-to-end testing.

Resolves #91

## Changes

### 1. Azure Load Balancer Module
**File**: `terraform/modules/azure-load-balancer/main.tf`
- ✅ Removed HA Ports load balancing rule (lines 96-109)
- ✅ Added documentation of Azure constraint
- ✅ Kept HTTP:80 and HTTPS:443 specific rules

**Reason**: Azure does not allow HA Ports rule (protocol=All, port=0) to coexist with specific port rules on the same frontend IP configuration.

**Alternative Options Documented**:
- Separate frontend IP configuration for HA ports, OR
- Remove HTTP/HTTPS specific rules and use HA ports only

### 2. F5 XC Registration Module
**File**: `terraform/modules/f5-xc-registration/main.tf`
- ✅ Removed pre-defined node_list block (lines 38-76)
- ✅ Changed to empty `not_managed {}` configuration
- ✅ Added auto-discovery documentation

**Reason**: F5 XC API rejects node_list during site creation - nodes must auto-discover after booting with registration token.

## Testing Results ✅

### Validation
- ✅ Terraform plan: Clean, no errors
- ✅ Terraform apply: Successfully created 39 resources
- ✅ Load balancer: HTTP + HTTPS rules operational
- ✅ F5 XC site: Created with auto-discovery enabled
- ✅ VMs: 2 CE instances deployed in HA zones
- ✅ Zero deployment errors

### Infrastructure Deployed
- 2x F5 XC CE AppStack VMs (Zone 1 & Zone 2)
- 1x Internal Load Balancer with backend pool
- 2x Health probes (TCP 65500, HTTPS 65443)
- 2x Load balancing rules (HTTP:80, HTTPS:443)
- 1x F5 XC Secure Mesh Site
- 1x F5 XC Registration Token
- Complete hub-spoke network topology

## Impact
- **Breaking**: Removes HA Ports load balancing rule
- **Current**: Application traffic (HTTP/HTTPS) remains fully functional
- **Future**: Document how to enable all-ports functionality if needed

## Pre-commit Checks
All checks passed:
- Terraform formatting
- Terraform validation
- TFLint validation
- Checkov security scan
- Terraform documentation

## Related
- Fixes errors discovered in PR #90 testing
- Complements backend resource group separation from #89