### PR TITLE
Replace ce_vm_size with ce_site_size for user-friendly CE sizing

### DIFF
--- a/specs/001-ce-cicd-automation/data-model.md
+++ b/specs/001-ce-cicd-automation/data-model.md
@@ -181,7 +181,7 @@ F5 Distributed Cloud Customer Edge running as Secure Mesh Site in hub VNET, prov
 | Attribute | Type | Required | Description | Validation |
 |-----------|------|----------|-------------|------------|
 | name | string | Yes | CE instance name | Must be unique in F5 XC tenant |
-| vm_size | string | Yes | Azure VM SKU | Minimum: `Standard_D8s_v5` (8 vCPUs, 32 GB RAM) |
+| vm_size | string | Yes | Azure VM SKU | Mapped from ce_site_size: medium=`Standard_D8_v4`, large=`Standard_D16_v4` |
 | os_disk_size_gb | number | Yes | OS disk size | Minimum: 80 GB |
 | sli_subnet_id | string | Yes | Subnet for inside interface (SLI) | Must be in NVA subnet |
 | slo_subnet_id | string | Yes | Subnet for outside interface (SLO) | Can be same as SLI or separate |
@@ -284,7 +284,7 @@ F5 Distributed Cloud Customer Edge running Managed Kubernetes in spoke VNET for 
 | Attribute | Type | Required | Description | Validation |
 |-----------|------|----------|-------------|------------|
 | name | string | Yes | CE K8s cluster name | Must be unique in F5 XC tenant |
-| vm_size | string | Yes | Azure VM SKU | Minimum: `Standard_D8s_v5` (8 vCPUs, 32 GB RAM) |
+| vm_size | string | Yes | Azure VM SKU | Mapped from ce_site_size: medium=`Standard_D8_v4`, large=`Standard_D16_v4` |
 | os_disk_size_gb | number | Yes | OS disk size | Minimum: 80 GB, recommend 100+ for K8s |
 | node_subnet_id | string | Yes | Subnet for K8s nodes | Must be in spoke workload subnet |
 | registration_token | string | Yes | F5 XC registration token | Sensitive, from volterra provider |

--- a/specs/001-ce-cicd-automation/quickstart.md
+++ b/specs/001-ce-cicd-automation/quickstart.md
@@ -242,7 +242,7 @@ spoke_workload_subnet_prefix = "10.1.1.0/24"
 spoke_service_subnet_prefix = "10.1.2.0/27"
 
 # CE Configuration
-ce_vm_size = "Standard_D8s_v5"
+ce_site_size = "medium"
 ce_os_disk_size_gb = 80
 ce_admin_password = "ComplexP@ssw0rd123!"  # Change this!
 

--- a/terraform/environments/dev/diagram.tf
+++ b/terraform/environments/dev/diagram.tf
@@ -52,7 +52,7 @@ resource "null_resource" "infrastructure_diagram" {
     peering_status      = jsonencode(module.spoke_vnet.peering_status)
 
     # Configuration changes
-    ce_vm_size   = var.ce_vm_size
+    ce_vm_size   = local.ce_vm_size
     azure_region = var.azure_region
 
     # Force regeneration on timestamp (optional - comment out for only real changes)

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -34,6 +34,15 @@ resource "tls_private_key" "ce_ssh" {
 locals {
   ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : tls_private_key.ce_ssh[0].public_key_openssh
 
+  # F5 XC CE site size to Azure VM SKU mapping
+  # Reference: https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-site-size-ref
+  ce_vm_size_map = {
+    medium = "Standard_D8_v4"  # 8 vCPUs, 32 GB RAM
+    large  = "Standard_D16_v4" # 16 vCPUs, 64 GB RAM
+  }
+
+  ce_vm_size = local.ce_vm_size_map[var.ce_site_size]
+
   # Identity information for F5 XC site labels and naming
   github_user = "robinmordasiewicz"
   github_repo = "f5-xc-ce-terraform"
@@ -127,7 +136,7 @@ module "ce_appstack_1" {
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   vm_name             = "${var.prefix}-vm-01" # f5-xc-ce-vm-01
-  vm_size             = var.ce_vm_size
+  vm_size             = local.ce_vm_size
   subnet_id           = module.hub_vnet.nva_subnet_id
   registration_token  = module.f5_xc_registration.registration_token
   ssh_public_key      = local.ssh_public_key
@@ -149,7 +158,7 @@ module "ce_appstack_2" {
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   vm_name             = "${var.prefix}-vm-02" # f5-xc-ce-vm-02
-  vm_size             = var.ce_vm_size
+  vm_size             = local.ce_vm_size
   subnet_id           = module.hub_vnet.nva_subnet_id
   registration_token  = module.f5_xc_registration.registration_token
   ssh_public_key      = local.ssh_public_key

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -70,9 +70,9 @@ f5_xc_namespace = "system"
 # CE VM Configuration
 # -------------------
 
-# VM size for CE instances (minimum: Standard_D8s_v3 = 8 vCPUs, 32 GB RAM)
-# See: https://docs.cloud.f5.com/docs/how-to/site-management/create-azure-site#azure-certified-hardware
-ce_vm_size = "Standard_D8s_v3"
+# CE site size (medium: 8 vCPUs/32GB RAM, large: 16 vCPUs/64GB RAM)
+# See: https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-site-size-ref
+ce_site_size = "medium"
 
 # SSH public key for CE VM access (REQUIRED)
 # Generate with: ssh-keygen -t rsa -b 4096 -f ~/.ssh/ce-azure-key

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -75,10 +75,15 @@ variable "f5_xc_tenant" {
 }
 
 # CE Configuration
-variable "ce_vm_size" {
-  description = "Azure VM size for CE instances (minimum Standard_D8s_v3)"
+variable "ce_site_size" {
+  description = "F5 XC CE site size - determines Azure VM SKU and resource allocation (medium: 8 vCPUs/32GB RAM, large: 16 vCPUs/64GB RAM)"
   type        = string
-  default     = "Standard_D8s_v3"
+  default     = "medium"
+
+  validation {
+    condition     = contains(["medium", "large"], var.ce_site_size)
+    error_message = "CE site size must be 'medium' or 'large'. Reference: https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-site-size-ref"
+  }
 }
 
 variable "ssh_public_key" {

--- a/tests/integration/module_test.go
+++ b/tests/integration/module_test.go
@@ -56,7 +56,7 @@ func TestCERegistration(t *testing.T) {
 			"location":            "eastus",
 			"ce_instance_name":    "test-ce",
 			"subnet_id":           "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/nva-subnet",
-			"vm_size":             "Standard_D8s_v3",
+			"vm_size":             "Standard_D8_v4",
 			"registration_token":  "test-registration-token",
 		},
 		NoColor: true,
@@ -171,7 +171,7 @@ func TestEndToEndDeployment(t *testing.T) {
 			"resource_group_name":    "xc-ce-test-rg",
 			"hub_vnet_address_space": []string{"10.0.0.0/16"},
 			"spoke_vnet_address_space": []string{"10.1.0.0/16"},
-			"ce_vm_size":             "Standard_D8s_v3",
+			"ce_site_size":           "medium",
 			"tags": map[string]string{
 				"environment": "test",
 				"managed_by":  "terraform",


### PR DESCRIPTION
## Summary
Replaces Azure SKU strings with user-friendly site size abstraction that matches F5 XC official documentation terminology.

## Changes
- ✅ Added `ce_site_size` variable with validation (medium|large)
- ✅ Created SKU mapping in locals block
- ✅ Updated all module calls to use `local.ce_vm_size`
- ✅ Updated terraform.tfvars.example
- ✅ Updated diagram.tf references
- ✅ Updated test fixtures
- ✅ Updated documentation in specs
- ✅ Terraform validation passed

## SKU Mapping
- `medium` → `Standard_D8_v4` (8 vCPUs, 32 GB RAM)
- `large` → `Standard_D16_v4` (16 vCPUs, 64 GB RAM)

## Benefits
- Users specify 'medium' or 'large' instead of Azure SKU strings
- Type-safe with Terraform validation
- Matches F5 XC official documentation
- Single source of truth for SKU mappings
- Easy to update when F5 changes supported sizes

## Breaking Change
Users must update their configuration:
```hcl
# OLD
ce_vm_size = "Standard_D8s_v3"

# NEW
ce_site_size = "medium"
```

## Reference
- F5 XC CE Site Sizing: https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-site-size-ref

## Testing
- ✅ Terraform validate passed
- ✅ Pre-commit hooks passed

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)