### PR TITLE
fix: change OS disk storage type from Premium_LRS to StandardSSD_LRS

### DIFF
--- a/terraform/modules/f5-xc-ce-appstack/main.tf
+++ b/terraform/modules/f5-xc-ce-appstack/main.tf
@@ -140,7 +140,7 @@ resource "azurerm_linux_virtual_machine" "ce" {
   os_disk {
     name                 = "${var.vm_name}-osdisk"
     caching              = "ReadWrite"
-    storage_account_type = "Premium_LRS"
+    storage_account_type = "StandardSSD_LRS" # Standard SSD per F5 XC documentation
     disk_size_gb         = 80
   }
 


### PR DESCRIPTION
## Summary
Changes OS disk storage type from `Premium_LRS` to `StandardSSD_LRS` to align with F5 XC documentation recommendations and Azure Dv4 series VM compatibility.

## Problem
- Current configuration uses `Premium_LRS` (Premium SSD) for OS disk
- Azure Dv4 series VMs (`Standard_D8_v4`, `Standard_D16_v4`) do **NOT** support Premium Storage
- F5 XC documentation recommends **Standard SSD** storage type for CE deployments

## Solution
- Updated `storage_account_type` from `"Premium_LRS"` to `"StandardSSD_LRS"` in `terraform/modules/f5-xc-ce-appstack/main.tf`
- Added inline comment referencing F5 XC documentation
- Validated Terraform configuration successfully

## Technical Details

### Azure Dv4 Series Storage Support
- ✅ **Supported**: `Standard_LRS`, `StandardSSD_LRS`
- ❌ **NOT Supported**: `Premium_LRS`

### F5 XC Recommended SKUs
- **Medium**: `Standard_D8_v4` (8 vCPUs, 32 GB RAM)
- **Large**: `Standard_D16_v4` (16 vCPUs, 64 GB RAM)

### Storage Performance
- **StandardSSD_LRS**: Up to 6,000 IOPS, 750 MB/s throughput (sufficient for CE workloads)
- **Premium_LRS**: Not applicable (unsupported by Dv4 series)

## Testing
- ✅ `terraform validate` passed
- ✅ Pre-commit hooks passed (terraform fmt, yaml, json, etc.)

## References
- F5 XC CE Site Sizing: https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-site-size-ref
- Azure Dv4 Series Specs: https://docs.microsoft.com/en-us/azure/virtual-machines/dv4-dsv4-series

## Files Changed
- `terraform/modules/f5-xc-ce-appstack/main.tf`: Line 143 storage type change

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)