### PR TITLE
feat: upgrade azurerm provider from 3.80 to 4.54

### DIFF
--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
 
     azuread = {

--- a/terraform/modules/azure-hub-vnet/main.tf
+++ b/terraform/modules/azure-hub-vnet/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
   }
 }

--- a/terraform/modules/azure-load-balancer/main.tf
+++ b/terraform/modules/azure-load-balancer/main.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
   }
 }
@@ -72,7 +72,7 @@ resource "azurerm_lb_rule" "https" {
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.ce_pool.id]
   probe_id                       = azurerm_lb_probe.ce_tcp.id
-  enable_floating_ip             = false
+  floating_ip_enabled            = false
   idle_timeout_in_minutes        = 4
   load_distribution              = "SourceIPProtocol" # Session affinity
 }
@@ -87,7 +87,7 @@ resource "azurerm_lb_rule" "http" {
   frontend_ip_configuration_name = "LoadBalancerFrontEnd"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.ce_pool.id]
   probe_id                       = azurerm_lb_probe.ce_tcp.id
-  enable_floating_ip             = false
+  floating_ip_enabled            = false
   idle_timeout_in_minutes        = 4
   load_distribution              = "SourceIPProtocol"
 }

--- a/terraform/modules/azure-spoke-vnet/main.tf
+++ b/terraform/modules/azure-spoke-vnet/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
   }
 }

--- a/terraform/modules/f5-xc-ce-appstack/main.tf
+++ b/terraform/modules/f5-xc-ce-appstack/main.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
   }
 }

--- a/terraform/modules/f5-xc-ce-k8s/main.tf
+++ b/terraform/modules/f5-xc-ce-k8s/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.80"
+      version = "~> 4.54"
     }
     volterra = {
       source  = "volterraedge/volterra"


### PR DESCRIPTION
## Summary
Upgrades the HashiCorp AzureRM Terraform provider from version `~> 3.80` to the latest stable release `~> 4.54`.

## Changes Made

### Provider Version Updates
Updated azurerm provider version in **6 files**:
- ✅ `terraform/environments/dev/versions.tf`
- ✅ `terraform/modules/azure-hub-vnet/main.tf`
- ✅ `terraform/modules/azure-load-balancer/main.tf`
- ✅ `terraform/modules/azure-spoke-vnet/main.tf`
- ✅ `terraform/modules/f5-xc-ce-appstack/main.tf`
- ✅ `terraform/modules/f5-xc-ce-k8s/main.tf`

### Deprecation Fixes
Fixed deprecation warnings in `azure-load-balancer` module:
- Changed `enable_floating_ip` → `floating_ip_enabled` (HTTP rule)
- Changed `enable_floating_ip` → `floating_ip_enabled` (HTTPS rule)

These changes address deprecation warnings for the upcoming provider version 5.0.

## Testing

### Initialization & Validation
```bash
✅ terraform init -upgrade
   - Successfully downloaded azurerm v4.54.0
   - All modules initialized

✅ terraform validate
   - Configuration valid
   - No warnings or errors
```

### Pre-commit Hooks
```bash
✅ terraform fmt - All files formatted
✅ All pre-commit checks passed
```

## Benefits

- 🆕 **Latest Features**: Access to new Azure resource types and features
- 🐛 **Bug Fixes**: Includes all bug fixes from versions 3.81 through 4.54
- 🔒 **Security**: Latest security patches and improvements
- ⚡ **Performance**: Provider performance enhancements
- 🔧 **Compatibility**: Better alignment with Azure API changes

## Version Comparison

| Component | Before | After |
|-----------|--------|-------|
| azurerm provider | ~> 3.80 | ~> 4.54 |
| Latest available | 3.116.0 | 4.54.0 |
| Major version jump | 3.x | 4.x |

## Breaking Changes Review

Reviewed the [4.0 Upgrade Guide](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/guides/4.0-upgrade-guide.html.markdown) and confirmed:
- ✅ No breaking changes affect our current resource usage
- ✅ Deprecated fields updated proactively
- ✅ All resources compatible with 4.x syntax

## References

- [AzureRM Provider v4.54.0](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.54.0)
- [4.0 Upgrade Guide](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/guides/4.0-upgrade-guide.html.markdown)
- [Full Changelog](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)