### PR TITLE
feat: upgrade azuread provider from 2.45 to 3.7

### DIFF
--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.45"
+      version = "~> 3.7"
     }
 
     volterra = {


### PR DESCRIPTION
## Summary
Upgrades the HashiCorp AzureAD Terraform provider from version `~> 2.45` to the latest stable release `~> 3.7`.

## Changes Made

### Provider Version Update
Updated azuread provider version:
- ✅ `terraform/environments/dev/versions.tf` (line 22)
- **Before**: `~> 2.45` (version 2.x series)
- **After**: `~> 3.7` (version 3.x series)

## Testing

### Initialization & Validation
```bash
✅ terraform init -upgrade
   - Successfully downloaded azuread v3.7.0
   - All modules initialized

✅ terraform validate
   - Configuration valid
   - No warnings or errors
```

### Pre-commit Hooks
```bash
✅ terraform fmt - All files formatted
✅ All pre-commit checks passed
```

## Benefits

- 🆕 **Latest Features**: Access to new Azure AD/Entra ID resource types and features
- 🐛 **Bug Fixes**: Includes all bug fixes from versions 2.46 through 3.7
- 🔒 **Security**: Latest security patches and improvements
- ⚡ **Performance**: Provider performance enhancements
- 🔧 **API Compatibility**: Better alignment with Microsoft Entra ID API changes

## Version Comparison

| Component | Before | After |
|-----------|--------|-------|
| azuread provider | ~> 2.45 | ~> 3.7 |
| Latest available | 2.53.1 | 3.7.0 |
| Major version jump | 2.x | 3.x |

## Breaking Changes Review

Reviewed the [3.0 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/3.0-upgrade-guide) and confirmed:
- ✅ No breaking changes affect our current resource usage
- ✅ No azuread resources currently used in configuration
- ✅ Provider authentication inherited from azurerm (OIDC)

## Current Usage

The azuread provider is configured but not actively used for resources in the current codebase:
- Authentication: Uses OIDC (`use_oidc = true`)
- Inherits authentication from azurerm provider
- Reserved for future Azure AD/Entra ID integrations

## References

- [AzureAD Provider v3.7.0](https://github.com/hashicorp/terraform-provider-azuread/releases/tag/v3.7.0)
- [3.0 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/3.0-upgrade-guide)
- [Full Changelog](https://github.com/hashicorp/terraform-provider-azuread/blob/main/CHANGELOG.md)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)