### PR TITLE
fix: disable accelerated networking for F5 XC CE VMs

### DIFF
--- a/terraform/modules/f5-xc-ce-appstack/variables.tf
+++ b/terraform/modules/f5-xc-ce-appstack/variables.tf
@@ -49,9 +49,9 @@ variable "availability_zone" {
 }
 
 variable "enable_accelerated_networking" {
-  description = "Enable accelerated networking for better performance"
+  description = "Enable accelerated networking. NOTE: Must be false for F5 XC CE VMs - accelerated networking creates bonded interfaces that fail VPM certified hardware check"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "admin_username" {


### PR DESCRIPTION
## Summary
- Disabled accelerated networking for F5 XC CE VMs to fix VPM registration failure
- Updated variable description to document the limitation

## Root Cause
Azure Accelerated Networking creates a bonded interface configuration where `eth1` becomes a slave of `eth0`. This bonded configuration doesn't match the VPM certified hardware profiles (`generic-single-nic` or `generic-multi-nic`), causing the VPM to fail with:

```
Error: fail to match certified hardware
Vpmd command error: fail to match certified hardware
```

## Test plan
- [ ] Deploy infrastructure with the fix
- [ ] Verify CE VMs have single interface (eth0 only)
- [ ] Confirm VPM starts without certified hardware error
- [ ] Verify CE nodes register with F5 XC Console
- [ ] Check site state changes from `WAITING_FOR_REGISTRATION` to `ONLINE`

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)